### PR TITLE
ISO19157-2 / Fix relative path to schema in ISO19157-2

### DIFF
--- a/ISO19157-2/dqm/1.0/2014-07-11/dataQualityMeasure copy.xsd
+++ b/ISO19157-2/dqm/1.0/2014-07-11/dataQualityMeasure copy.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" 
   xmlns:cit="http://www.isotc211.org/namespace/cit/1.0/2014-07-11" 
-  xmlns:dqm="http://www.isotc211.org/2005/dqm/1.0/2014-07-11" 
+  xmlns:dqm="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11"
   xmlns:gco="http://www.isotc211.org/2005/gco" 
   xmlns:mcc="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" 
-  elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/2005/dqm/1.0/2014-07-11" version="">
+  elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" version="">
   <include schemaLocation="dqm.xsd"/>
   <!-- Changed schema location to address gml vs. gml/3.2 problem Ted Habermann 2013-12-26 -->
   <!--<import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>-->

--- a/ISO19157-2/dqm/1.0/2014-07-11/dataQualityMeasure.xsd
+++ b/ISO19157-2/dqm/1.0/2014-07-11/dataQualityMeasure.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:cit="http://www.isotc211.org/namespace/cit/1.0/2014-07-11" 
-  xmlns:dqm="http://www.isotc211.org/2005/dqm/1.0/2014-07-11" 
+  xmlns:dqm="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11"
   xmlns:gco="http://www.isotc211.org/2005/gco" 
   xmlns:mcc="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" 
-  elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/2005/dqm/1.0/2014-07-11" version="">
+  elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" version="">
   <include schemaLocation="dqm.xsd"/>
   <!-- Changed schema location to address gml vs. gml/3.2 problem Ted Habermann 2013-12-26 -->
   <!--<import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>-->

--- a/ISO19157-2/dqm/1.0/2014-07-11/dqm.xsd
+++ b/ISO19157-2/dqm/1.0/2014-07-11/dqm.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:cat="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" xmlns:dqm="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" xmlns:mcc="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" xmlns:pre="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" version="1.0">
   <include schemaLocation="qualityMeasures.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" schemaLocation="../../../ISO19115-3/cat/1.0/cat.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" schemaLocation="../../../ISO19115-3/mcc/1.0/mcc.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" schemaLocation="../../../ISO19135/pre/1.0/pre.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" schemaLocation="../../../../ISO19115-3/cat/1.0/2014-07-11/cat.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" schemaLocation="../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" schemaLocation="../../../../ISO19135/pre/1.0/2014-07-11/pre.xsd"/>
   <!--XML Schema document created by ShapeChange - http://shapechange.net/-->
 </schema>

--- a/ISO19157-2/dqm/1.0/2014-07-11/qualityMeasures.xsd
+++ b/ISO19157-2/dqm/1.0/2014-07-11/qualityMeasures.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:cat="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" xmlns:dqm="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:mcc="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" xmlns:pre="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" elementFormDefault="qualified" targetNamespace="http://www.isotc211.org/namespace/dqm/1.0/2014-07-11" version="1.0">
   <include schemaLocation="dqm.xsd"/>
   <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" schemaLocation="../../../ISO19115-3/cat/1.0/cat.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" schemaLocation="../../../ISO19115-3/mcc/1.0/mcc.xsd"/>
-  <import namespace="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" schemaLocation="../../../ISO19135/pre/1.0/pre.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/cat/1.0/2014-07-11" schemaLocation="../../../../ISO19115-3/cat/1.0/2014-07-11/cat.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/mcc/1.0/2014-07-11" schemaLocation="../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd"/>
+  <import namespace="http://www.isotc211.org/namespace/pre/1.0/2014-07-11" schemaLocation="../../../../ISO19135/pre/1.0/2014-07-11/pre.xsd"/>
   <!--XML Schema document created by ShapeChange - http://shapechange.net/-->
   <element name="DQM_BasicMeasure" substitutionGroup="gco:AbstractObject" type="dqm:DQM_BasicMeasure_Type">
     <annotation>


### PR DESCRIPTION
related to change from 2005 to namespace in file path 2ce159c0f79fc5e62962a9a74f4435b63d86cd00.
