### PR TITLE
Complete Import List

### DIFF
--- a/ISO19110/fcc/1.0/2014-07-11/index.html
+++ b/ISO19110/fcc/1.0/2014-07-11/index.html
@@ -13,21 +13,32 @@
       </p>
       <h2>XML Schema for fcc 1.0</h2>
       <p><b>fcc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the fcc 1.0 namespace or by
-         XML Schema documents importing the fcc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the fcc namespace,
-         but it does not contain the declaration of any types.
+         in the fcc 1.0 namespace or by XML Schema documents importing the fcc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the fcc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for fcc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for fcc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for fcc 1.0</h2>
       <p><b>abstract.xsd</b> implements the UML conceptual schema defined in ISO 19110, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: Abstract_FeatureCatalogue, and Abstract_FeatureType
       </p>
-      <h2>No Related XML Namespaces for fcc 1.0</h2>
-      <h2>Schematron Validation Rules for fcc 1.0</h2> Schematron rules for validating instance documents of the fcc 1.0 namespace are in
-      fcc.sch. Other schematron rule sets that are required for a complete validation are: 
+      <h2>Related XML Namespaces for fcc 1.0</h2> The fcc 1.0 namespace imports these other namespaces: 
+      <table border="1" cellpadding="3" cellspacing="3">
+         <tr>
+            <th>Name</th>
+            <th>Standard Prefix</th>
+            <th>Namespace Location</th>
+            <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+      </table>
+      <h2>Schematron Validation Rules for fcc 1.0</h2> Schematron rules for validating instance documents of the fcc 1.0 namespace are in fcc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19110/gfc/1.1/2014-07-11/index.html
+++ b/ISO19110/gfc/1.1/2014-07-11/index.html
@@ -18,13 +18,11 @@
       </p>
       <h2>XML Schema for gfc 1.1</h2>
       <p><b>gfc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the gfc 1.1 namespace or by
-         XML Schema documents importing the gfc 1.1 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the gfc namespace,
-         but it does not contain the declaration of any types.
+         in the gfc 1.1 namespace or by XML Schema documents importing the gfc 1.1 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the gfc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for gfc 1.1 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for gfc 1.1 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for gfc 1.1</h2>
       <p><b>featureCatalogue.xsd</b> implements the UML conceptual schema defined in ISO 19110, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: FC_AssociationRole, FC_Binding, FC_BoundAssociationRole, FC_BoundFeatureAttribute, AbstractFC_CarrierOfCharacteristics, FC_Constraint, FC_DefinitionReference, FC_DefinitionSource, FC_FeatureAssociation, FC_FeatureAttribute, FC_FeatureCatalogue, FC_FeatureOperation, FC_FeatureType, FC_InheritanceRelation, FC_ListedValue, FC_LocalisedDefinitionReference, AbstractFC_PropertyType, and FC_RoleType
@@ -38,33 +36,44 @@
             <th>Schema Location</th>
          </tr>
          <tr>
-            <td>Citation and responsible party information</td>
-            <td>cit</td>
-            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
+            <td></td>
+            <td>3.2</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
          </tr>
          <tr>
-            <td>Feature Catalog Common</td>
-            <td>fcc</td>
+            <td>Citation and responsible party information</td>
+            <td>cit</td>
             <td>http://www.isotc211.org/namespace/fcc/1.0/2014-07-11</td>
             <td>../../../../ISO19110/fcc/1.0/2014-07-11/fcc.xsd</td>
          </tr>
          <tr>
-            <td>Language localization</td>
-            <td>lan</td>
+            <td>Feature Catalog Common</td>
+            <td>fcc</td>
             <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/lan/1.0/2014-07-11/lan.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td>Language localization</td>
+            <td>lan</td>
+            <td>http://www.opengis.net/gml/3.2</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19136_Schemas/gml.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for gfc 1.1</h2> Schematron rules for validating instance documents of the gfc 1.1 namespace are in
-      gfc.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, fcc.sch, lan.sch, and mcc.sch
+      <h2>Schematron Validation Rules for gfc 1.1</h2> Schematron rules for validating instance documents of the gfc 1.1 namespace are in gfc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, fcc.sch, lan.sch, mcc.sch, 3.2.sch, cit.sch, fcc.sch, lan.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19111/rbc/1.0/2014-07-11/index.html
+++ b/ISO19111/rbc/1.0/2014-07-11/index.html
@@ -18,13 +18,11 @@
       </p>
       <h2>XML Schema for rbc 1.0</h2>
       <p><b>rbc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the rbc 1.0 namespace or by
-         XML Schema documents importing the rbc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the rbc namespace,
-         but it does not contain the declaration of any types.
+         in the rbc 1.0 namespace or by XML Schema documents importing the rbc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the rbc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for rbc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for rbc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for rbc 1.0</h2>
       <p><b>coordinateOperations.xsd</b> implements the UML conceptual schema defined in ISO 19111, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: CC_ConcatenatedOperation, CC_Conversion, CC_CoordinateOperation, CC_Formula, AbstractCC_GeneralOperationParameter, AbstractCC_GeneralParameterValue, CC_OperationMethod, CC_OperationParameter, CC_OperationParameterGroup, CC_OperationParameterValue, CC_ParameterValue, CC_ParameterValueGroup, CC_PassThroughOperation, AbstractCC_SingleOperation, and CC_Transformation
@@ -53,27 +51,38 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>3.2</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Data Quality Common Classes</td>
             <td>dqc</td>
             <td>http://www.isotc211.org/namespace/dqc/1.0/2014-07-11</td>
             <td>../../../../ISO19157/dqc/1.0/dqc.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
-            <td>Referencing By Coordinates Common</td>
-            <td>rce</td>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
             <td>http://www.isotc211.org/namespace/rce/1.0/2014-07-11</td>
             <td>../../../../ISO19111/rce/1.0/2014-07-11/rce.xsd</td>
          </tr>
+         <tr>
+            <td>Referencing By Coordinates Common</td>
+            <td>rce</td>
+            <td>http://www.opengis.net/gml/3.2</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19136_Schemas/gml.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for rbc 1.0</h2> Schematron rules for validating instance documents of the rbc 1.0 namespace are in
-      rbc.sch. Other schematron rule sets that are required for a complete validation are: dqc.sch, mcc.sch, and rce.sch
+      <h2>Schematron Validation Rules for rbc 1.0</h2> Schematron rules for validating instance documents of the rbc 1.0 namespace are in rbc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, dqc.sch, mcc.sch, rce.sch, 3.2.sch, gco.sch, mcc.sch, rce.sch, 3.2.sch, gco.sch, rce.sch, gco.sch, mcc.sch, rce.sch, gco.sch, dqc.sch, mcc.sch, and rce.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19111/rce/1.0/2014-07-11/index.html
+++ b/ISO19111/rce/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for rce 1.0</h2>
       <p><b>rce.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the rce 1.0 namespace or by
-         XML Schema documents importing the rce 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the rce namespace,
-         but it does not contain the declaration of any types.
+         in the rce 1.0 namespace or by XML Schema documents importing the rce 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the rce namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for rce 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for rce 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for rce 1.0</h2>
       <p><b>abstractClasses.xsd</b> implements the UML conceptual schema defined in ISO 19110, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: AbstractIO_IdentifiedObjectBase, Abstract_CRS_Datum, Abstract_CoordinateReferenceSystem, and Abstract_CoordinateSystem
@@ -33,15 +31,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for rce 1.0</h2> Schematron rules for validating instance documents of the rce 1.0 namespace are in
-      rce.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for rce 1.0</h2> Schematron rules for validating instance documents of the rce 1.0 namespace are in rce.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, mcc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/cat/1.0/2014-07-11/index.html
+++ b/ISO19115-3/cat/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for cat 1.0</h2>
       <p><b>cat.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the cat 1.0 namespace or by
-         XML Schema documents importing the cat 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the cat namespace,
-         but it does not contain the declaration of any types.
+         in the cat 1.0 namespace or by XML Schema documents importing the cat 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the cat namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for cat 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for cat 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for cat 1.0</h2>
       <p><b>catalogues.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 7.4.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: AbstractCT_Catalogue, and AbstractCT_Item
@@ -40,15 +38,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
-            <td>Language localization</td>
-            <td>lan</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/lan/1.0/2014-07-11/lan.xsd</td>
          </tr>
+         <tr>
+            <td>Language localization</td>
+            <td>lan</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for cat 1.0</h2> Schematron rules for validating instance documents of the cat 1.0 namespace are in
-      cat.sch. Other schematron rule sets that are required for a complete validation are: lan.sch
+      <h2>Schematron Validation Rules for cat 1.0</h2> Schematron rules for validating instance documents of the cat 1.0 namespace are in cat.sch. Other schematron rule sets that are required for a complete validation are: lan.sch, gco.sch, lan.sch, gco.sch, gco.sch, and gco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/cit/1.0/2014-07-11/index.html
+++ b/ISO19115-3/cit/1.0/2014-07-11/index.html
@@ -11,21 +11,38 @@
       </p>
       <h2>XML Schema for cit 1.0</h2>
       <p><b>cit.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the cit 1.0 namespace or by
-         XML Schema documents importing the cit 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the cit namespace,
-         but it does not contain the declaration of any types.
+         in the cit 1.0 namespace or by XML Schema documents importing the cit 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the cit namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for cit 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for cit 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for cit 1.0</h2>
       <p><b>citation.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.6.3. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: CI_Address, CI_Citation, CI_Contact, CI_Date, CI_DateTypeCode, CI_Individual, CI_OnLineFunctionCode, CI_OnlineResource, CI_Organisation, AbstractCI_Party, CI_PresentationFormCode, CI_Responsibility, CI_RoleCode, CI_Series, CI_Telephone, and CI_TelephoneTypeCode
       </p>
-      <h2>No Related XML Namespaces for cit 1.0</h2>
-      <h2>Schematron Validation Rules for cit 1.0</h2> Schematron rules for validating instance documents of the cit 1.0 namespace are in
-      cit.sch. Other schematron rule sets that are required for a complete validation are: 
+      <h2>Related XML Namespaces for cit 1.0</h2> The cit 1.0 namespace imports these other namespaces: 
+      <table border="1" cellpadding="3" cellspacing="3">
+         <tr>
+            <th>Name</th>
+            <th>Standard Prefix</th>
+            <th>Namespace Location</th>
+            <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+         </tr>
+      </table>
+      <h2>Schematron Validation Rules for cit 1.0</h2> Schematron rules for validating instance documents of the cit 1.0 namespace are in cit.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/gcx/1.0/2014-07-11/index.html
+++ b/ISO19115-3/gcx/1.0/2014-07-11/index.html
@@ -11,21 +11,44 @@
       </p>
       <h2>XML Schema for gcx 1.0</h2>
       <p><b>gcx.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the gcx 1.0 namespace or by
-         XML Schema documents importing the gcx 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the gcx namespace,
-         but it does not contain the declaration of any types.
+         in the gcx 1.0 namespace or by XML Schema documents importing the gcx 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the gcx namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for gcx 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for gcx 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for gcx 1.0</h2>
       <p><b>extendedTypes.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 7.2. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: FileName, MimeFileType, and Anchor
       </p>
-      <h2>No Related XML Namespaces for gcx 1.0</h2>
-      <h2>Schematron Validation Rules for gcx 1.0</h2> Schematron rules for validating instance documents of the gcx 1.0 namespace are in
-      gcx.sch. Other schematron rule sets that are required for a complete validation are: 
+      <h2>Related XML Namespaces for gcx 1.0</h2> The gcx 1.0 namespace imports these other namespaces: 
+      <table border="1" cellpadding="3" cellspacing="3">
+         <tr>
+            <th>Name</th>
+            <th>Standard Prefix</th>
+            <th>Namespace Location</th>
+            <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.w3.org/1999/xlink</td>
+            <td>http://www.w3.org/1999/xlink.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>xlink</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+      </table>
+      <h2>Schematron Validation Rules for gcx 1.0</h2> Schematron rules for validating instance documents of the gcx 1.0 namespace are in gcx.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, xlink.sch, gco.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/gex/1.0/2014-07-11/index.html
+++ b/ISO19115-3/gex/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for gex 1.0</h2>
       <p><b>gex.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the gex 1.0 namespace or by
-         XML Schema documents importing the gex 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the gex namespace,
-         but it does not contain the declaration of any types.
+         in the gex 1.0 namespace or by XML Schema documents importing the gex 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the gex namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for gex 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for gex 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for gex 1.0</h2>
       <p><b>extent.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.6.1. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: EX_BoundingPolygon, EX_Extent, EX_GeographicBoundingBox, EX_GeographicDescription, AbstractEX_GeographicExtent, EX_SpatialTemporalExtent, EX_TemporalExtent, and EX_VerticalExtent
@@ -31,6 +29,24 @@
             <th>Standard Prefix</th>
             <th>Namespace Location</th>
             <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gss</td>
+            <td>http://www.isotc211.org/2005/gss</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gss/gss.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gts</td>
+            <td>http://www.isotc211.org/2005/gts</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gts/gts.xsd</td>
          </tr>
          <tr>
             <td>Metadata Common Classes</td>
@@ -45,9 +61,8 @@
             <td>../../../../ISO19111/rce/1.0/2014-07-11/rce.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for gex 1.0</h2> Schematron rules for validating instance documents of the gex 1.0 namespace are in
-      gex.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch, and rce.sch
+      <h2>Schematron Validation Rules for gex 1.0</h2> Schematron rules for validating instance documents of the gex 1.0 namespace are in gex.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gss.sch, gts.sch, mcc.sch, rce.sch, mcc.sch, and rce.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/lan/1.0/2014-07-11/index.html
+++ b/ISO19115-3/lan/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for lan 1.0</h2>
       <p><b>lan.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the lan 1.0 namespace or by
-         XML Schema documents importing the lan 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the lan namespace,
-         but it does not contain the declaration of any types.
+         in the lan 1.0 namespace or by XML Schema documents importing the lan 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the lan namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for lan 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for lan 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for lan 1.0</h2>
       <p><b>language.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 7.3. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: CountryCode, LanguageCode, LocalisedCharacterString, MD_CharacterSetCode, PT_FreeText, PT_Locale, and PT_LocaleContainer
@@ -36,10 +34,15 @@
             <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for lan 1.0</h2> Schematron rules for validating instance documents of the lan 1.0 namespace are in
-      lan.sch. Other schematron rule sets that are required for a complete validation are: cit.sch
+      <h2>Schematron Validation Rules for lan 1.0</h2> Schematron rules for validating instance documents of the lan 1.0 namespace are in lan.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, gco.sch, and cit.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mas/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mas/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mas 1.0</h2>
       <p><b>mas.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mas 1.0 namespace or by
-         XML Schema documents importing the mas 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mas namespace,
-         but it does not contain the declaration of any types.
+         in the mas 1.0 namespace or by XML Schema documents importing the mas 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mas namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mas 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mas 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mas 1.0</h2>
       <p><b>applicationSchema.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.13. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_ApplicationSchemaInformation
@@ -33,19 +31,24 @@
          <tr>
             <td>Citation and responsible party information</td>
             <td>cit</td>
-            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
-            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mas 1.0</h2> Schematron rules for validating instance documents of the mas 1.0 namespace are in
-      mas.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, and mcc.sch
+      <h2>Schematron Validation Rules for mas 1.0</h2> Schematron rules for validating instance documents of the mas 1.0 namespace are in mas.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, mcc.sch, cit.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mcc/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mcc/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for mcc 1.0</h2>
       <p><b>mcc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mcc 1.0 namespace or by
-         XML Schema documents importing the mcc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mcc namespace,
-         but it does not contain the declaration of any types.
+         in the mcc 1.0 namespace or by XML Schema documents importing the mcc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mcc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mcc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mcc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mcc 1.0</h2>
       <p><b>AbstractCommonClasses.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.6.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: Abstract_AcquisitionInformation, Abstract_ApplicationSchemaInformation, Abstract_Citation, Abstract_Constraints, Abstract_ContentInformation, Abstract_Distribution, Abstract_Extent, Abstract_Format, Abstract_LineageInformation, Abstract_MaintenanceInformation, Abstract_Metadata, Abstract_MetadataExtension, Abstract_OnlineResource, Abstract_Platform, Abstract_PortrayalCatalogueInformation, Abstract_ReferenceSystem, Abstract_ResourceDescription, Abstract_Responsibility, Abstract_SpatialRepresentation, Abstract_SpatialResolution, Abstract_StandardOrderProcess, and Abstract_TypedDate
@@ -27,10 +25,23 @@
       <p><b>commonClasses.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.6.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_BrowseGraphic, MD_Identifier, MD_ProgressCode, MD_Scope, MD_ScopeCode, MD_ScopeDescription, MD_SpatialRepresentationTypeCode, and URI
       </p>
-      <h2>No Related XML Namespaces for mcc 1.0</h2>
-      <h2>Schematron Validation Rules for mcc 1.0</h2> Schematron rules for validating instance documents of the mcc 1.0 namespace are in
-      mcc.sch. Other schematron rule sets that are required for a complete validation are: 
+      <h2>Related XML Namespaces for mcc 1.0</h2> The mcc 1.0 namespace imports these other namespaces: 
+      <table border="1" cellpadding="3" cellspacing="3">
+         <tr>
+            <th>Name</th>
+            <th>Standard Prefix</th>
+            <th>Namespace Location</th>
+            <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+      </table>
+      <h2>Schematron Validation Rules for mcc 1.0</h2> Schematron rules for validating instance documents of the mcc 1.0 namespace are in mcc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, and gco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mco/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mco/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mco 1.0</h2>
       <p><b>mco.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mco 1.0 namespace or by
-         XML Schema documents importing the mco 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mco namespace,
-         but it does not contain the declaration of any types.
+         in the mco 1.0 namespace or by XML Schema documents importing the mco 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mco namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mco 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mco 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mco 1.0</h2>
       <p><b>constraints.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_ClassificationCode, MD_Constraints, MD_LegalConstraints, MD_Releasability, MD_RestrictionCode, and MD_SecurityConstraints
@@ -31,15 +29,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mco 1.0</h2> Schematron rules for validating instance documents of the mco 1.0 namespace are in
-      mco.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mco 1.0</h2> Schematron rules for validating instance documents of the mco 1.0 namespace are in mco.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, mcc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/md1/1.0/2014-07-11/index.html
+++ b/ISO19115-3/md1/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for md1 1.0</h2>
       <p><b>md1.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the md1 1.0 namespace or by
-         XML Schema documents importing the md1 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the md1 namespace,
-         but it does not contain the declaration of any types.
+         in the md1 1.0 namespace or by XML Schema documents importing the md1 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the md1 namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for md1 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for md1 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for md1 1.0</h2>
       <p><b>metadataWExtendedType.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, A.2.3.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: 
@@ -69,9 +67,8 @@
             <td>../../../../ISO19115-3/mri/1.0/2014-07-11/mri.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for md1 1.0</h2> Schematron rules for validating instance documents of the md1 1.0 namespace are in
-      md1.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, gcx.sch, lan.sch, mcc.sch, mds.sch, and mri.sch
+      <h2>Schematron Validation Rules for md1 1.0</h2> Schematron rules for validating instance documents of the md1 1.0 namespace are in md1.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, gcx.sch, lan.sch, mcc.sch, mds.sch, and mri.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/md2/1.0/2014-07-11/index.html
+++ b/ISO19115-3/md2/1.0/2014-07-11/index.html
@@ -14,13 +14,11 @@
       </p>
       <h2>XML Schema for md2 1.0</h2>
       <p><b>md2.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the md2 1.0 namespace or by
-         XML Schema documents importing the md2 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the md2 namespace,
-         but it does not contain the declaration of any types.
+         in the md2 1.0 namespace or by XML Schema documents importing the md2 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the md2 namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for md2 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for md2 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for md2 1.0</h2>
       <p><b>metadataWithExtensions.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, A.2.3.5. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: 
@@ -82,9 +80,8 @@
             <td>../../../../ISO19115-3/mri/1.0/2014-07-11/mri.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for md2 1.0</h2> Schematron rules for validating instance documents of the md2 1.0 namespace are in
-      md2.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, gcx.sch, lan.sch, mcc.sch, md1.sch, mex.sch, mpc.sch, and mri.sch
+      <h2>Schematron Validation Rules for md2 1.0</h2> Schematron rules for validating instance documents of the md2 1.0 namespace are in md2.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, gcx.sch, lan.sch, mcc.sch, md1.sch, mex.sch, mpc.sch, and mri.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mda/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mda/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for mda 1.0</h2>
       <p><b>mda.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mda 1.0 namespace or by
-         XML Schema documents importing the mda 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mda namespace,
-         but it does not contain the declaration of any types.
+         in the mda 1.0 namespace or by XML Schema documents importing the mda 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mda namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mda 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mda 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mda 1.0</h2>
       <p><b>metadataApplication.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.2. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: AbstractDS_Aggregate, DS_DataSet, DS_Initiative, DS_OtherAggregate, DS_Platform, DS_ProductionSeries, AbstractDS_Resource, DS_Sensor, DS_Series, and SV_Service
@@ -33,15 +31,26 @@
             <th>Schema Location</th>
          </tr>
          <tr>
-            <td>Metadata for Data and Services with Geospatial Common Extensions</td>
-            <td>md2</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/md2/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/md2/1.0/2014-07-11/md2.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata for Data and Services with Geospatial Common Extensions</td>
+            <td>md2</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata Base</td>
+            <td>mdb</td>
+            <td>http://www.isotc211.org/namespace/mdb/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mdb/1.0/2014-07-11/mdb.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mda 1.0</h2> Schematron rules for validating instance documents of the mda 1.0 namespace are in
-      mda.sch. Other schematron rule sets that are required for a complete validation are: md2.sch
+      <h2>Schematron Validation Rules for mda 1.0</h2> Schematron rules for validating instance documents of the mda 1.0 namespace are in mda.sch. Other schematron rule sets that are required for a complete validation are: md2.sch, gco.sch, and mdb.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mdb/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mdb/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for mdb 1.0</h2>
       <p><b>mdb.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mdb 1.0 namespace or by
-         XML Schema documents importing the mdb 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mdb namespace,
-         but it does not contain the declaration of any types.
+         in the mdb 1.0 namespace or by XML Schema documents importing the mdb 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mdb namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mdb 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mdb 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mdb 1.0</h2>
       <p><b>metadataBase.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.2. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_Metadata, and MD_MetadataScope
@@ -45,27 +43,32 @@
             <td>../../../../ISO19157-2/dqc/1.0/2014-07-11/dqc.xsd</td>
          </tr>
          <tr>
-            <td>Language localization</td>
-            <td>lan</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/lan/1.0/2014-07-11/lan.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td>Language localization</td>
+            <td>lan</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
-            <td>Metadata for Resource Identification</td>
-            <td>mri</td>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mri/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mri/1.0/2014-07-11/mri.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata for Resource Identification</td>
+            <td>mri</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mdb 1.0</h2> Schematron rules for validating instance documents of the mdb 1.0 namespace are in
-      mdb.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, dqc.sch, lan.sch, mcc.sch, and mri.sch
+      <h2>Schematron Validation Rules for mdb 1.0</h2> Schematron rules for validating instance documents of the mdb 1.0 namespace are in mdb.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, dqc.sch, lan.sch, mcc.sch, mri.sch, gco.sch, dqc.sch, lan.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mds/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mds/1.0/2014-07-11/index.html
@@ -16,13 +16,11 @@
       </p>
       <h2>XML Schema for mds 1.0</h2>
       <p><b>mds.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mds 1.0 namespace or by
-         XML Schema documents importing the mds 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mds namespace,
-         but it does not contain the declaration of any types.
+         in the mds 1.0 namespace or by XML Schema documents importing the mds 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mds namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mds 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mds 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mds 1.0</h2>
       <p><b>metadataDataServices.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.2. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: 
@@ -126,9 +124,8 @@
             <td>../../../../ISO19115-3/srv/2.0/2014-07-11/srv.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mds 1.0</h2> Schematron rules for validating instance documents of the mds 1.0 namespace are in
-      mds.sch. Other schematron rule sets that are required for a complete validation are: fcc.sch, gex.sch, mac.sch, mas.sch, mco.sch, mdb.sch, mdq.sch, mmi.sch, mpc.sch, mrc.sch, mrd.sch, mrl.sch, mrs.sch, msr.sch, and srv.sch
+      <h2>Schematron Validation Rules for mds 1.0</h2> Schematron rules for validating instance documents of the mds 1.0 namespace are in mds.sch. Other schematron rule sets that are required for a complete validation are: fcc.sch, gex.sch, mac.sch, mas.sch, mco.sch, mdb.sch, mdq.sch, mmi.sch, mpc.sch, mrc.sch, mrd.sch, mrl.sch, mrs.sch, msr.sch, and srv.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mdt/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mdt/1.0/2014-07-11/index.html
@@ -16,13 +16,11 @@
       </p>
       <h2>XML Schema for mdt 1.0</h2>
       <p><b>mdt.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mdt 1.0 namespace or by
-         XML Schema documents importing the mdt 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mdt namespace,
-         but it does not contain the declaration of any types.
+         in the mdt 1.0 namespace or by XML Schema documents importing the mdt 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mdt namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mdt 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mdt 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mdt 1.0</h2>
       <p><b>metadataTransfer.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 7.4.2, 7.4.3. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MX_Aggregate, MX_DataFile, MX_DataSet, AbstractMX_File, MX_ScopeCode, and MX_SupportFile
@@ -42,21 +40,26 @@
             <td>../../../../ISO19115-3/cat/1.0/2014-07-11/cat.xsd</td>
          </tr>
          <tr>
-            <td>Geospatial Common eXtension</td>
-            <td>gcx</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/gcx/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/gcx/1.0/2014-07-11/gcx.xsd</td>
          </tr>
          <tr>
-            <td>MetaData Application</td>
-            <td>mda</td>
+            <td>Geospatial Common eXtension</td>
+            <td>gcx</td>
             <td>http://www.isotc211.org/namespace/mda/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mda/1.0/2014-07-11/mda.xsd</td>
          </tr>
+         <tr>
+            <td>MetaData Application</td>
+            <td>mda</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mdt 1.0</h2> Schematron rules for validating instance documents of the mdt 1.0 namespace are in
-      mdt.sch. Other schematron rule sets that are required for a complete validation are: cat.sch, gcx.sch, and mda.sch
+      <h2>Schematron Validation Rules for mdt 1.0</h2> Schematron rules for validating instance documents of the mdt 1.0 namespace are in mdt.sch. Other schematron rule sets that are required for a complete validation are: cat.sch, gcx.sch, mda.sch, gco.sch, cat.sch, gcx.sch, and mda.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mex/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mex/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mex 1.0</h2>
       <p><b>mex.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mex 1.0 namespace or by
-         XML Schema documents importing the mex 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mex namespace,
-         but it does not contain the declaration of any types.
+         in the mex 1.0 namespace or by XML Schema documents importing the mex 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mex namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mex 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mex 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mex 1.0</h2>
       <p><b>metadataExtension.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.12. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_DatatypeCode, MD_ExtendedElementInformation, MD_MetadataExtensionInformation, and MD_ObligationCode
@@ -31,15 +29,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mex 1.0</h2> Schematron rules for validating instance documents of the mex 1.0 namespace are in
-      mex.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mex 1.0</h2> Schematron rules for validating instance documents of the mex 1.0 namespace are in mex.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, mcc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mmi/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mmi/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mmi 1.0</h2>
       <p><b>mmi.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mmi 1.0 namespace or by
-         XML Schema documents importing the mmi 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mmi namespace,
-         but it does not contain the declaration of any types.
+         in the mmi 1.0 namespace or by XML Schema documents importing the mmi 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mmi namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mmi 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mmi 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mmi 1.0</h2>
       <p><b>maintenance.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.6. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_MaintenanceFrequencyCode, and MD_MaintenanceInformation
@@ -31,15 +29,26 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gts</td>
+            <td>http://www.isotc211.org/2005/gts</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gts/gts.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mmi 1.0</h2> Schematron rules for validating instance documents of the mmi 1.0 namespace are in
-      mmi.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mmi 1.0</h2> Schematron rules for validating instance documents of the mmi 1.0 namespace are in mmi.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gts.sch, mcc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mpc/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mpc/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mpc 1.0</h2>
       <p><b>mpc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mpc 1.0 namespace or by
-         XML Schema documents importing the mpc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mpc namespace,
-         but it does not contain the declaration of any types.
+         in the mpc 1.0 namespace or by XML Schema documents importing the mpc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mpc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mpc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mpc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mpc 1.0</h2>
       <p><b>portrayalCatalogue.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.10. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_PortrayalCatalogueReference
@@ -31,15 +29,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mpc 1.0</h2> Schematron rules for validating instance documents of the mpc 1.0 namespace are in
-      mpc.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mpc 1.0</h2> Schematron rules for validating instance documents of the mpc 1.0 namespace are in mpc.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch, gco.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mrc/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mrc/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mrc 1.0</h2>
       <p><b>mrc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mrc 1.0 namespace or by
-         XML Schema documents importing the mrc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mrc namespace,
-         but it does not contain the declaration of any types.
+         in the mrc 1.0 namespace or by XML Schema documents importing the mrc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mrc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mrc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mrc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mrc 1.0</h2>
       <p><b>content.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.9. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_AttributeGroup, MD_Band, AbstractMD_ContentInformation, MD_CoverageContentTypeCode, MD_CoverageDescription, MD_FeatureCatalogue, MD_FeatureCatalogueDescription, MD_FeatureTypeInfo, MD_ImageDescription, MD_ImagingConditionCode, MD_RangeDimension, and MD_SampleDimension
@@ -36,6 +34,12 @@
          <tr>
             <td>Feature Catalog Common</td>
             <td>fcc</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/fcc/1.0/2014-07-11</td>
             <td>../../../../ISO19110/fcc/1.0/2014-07-11/fcc.xsd</td>
          </tr>
@@ -52,9 +56,8 @@
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mrc 1.0</h2> Schematron rules for validating instance documents of the mrc 1.0 namespace are in
-      mrc.sch. Other schematron rule sets that are required for a complete validation are: fcc.sch, lan.sch, and mcc.sch
+      <h2>Schematron Validation Rules for mrc 1.0</h2> Schematron rules for validating instance documents of the mrc 1.0 namespace are in mrc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, fcc.sch, lan.sch, mcc.sch, gco.sch, fcc.sch, lan.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mrd/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mrd/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mrd 1.0</h2>
       <p><b>mrd.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mrd 1.0 namespace or by
-         XML Schema documents importing the mrd 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mrd namespace,
-         but it does not contain the declaration of any types.
+         in the mrd 1.0 namespace or by XML Schema documents importing the mrd 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mrd namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mrd 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mrd 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mrd 1.0</h2>
       <p><b>distribution.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.11. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_DigitalTransferOptions, MD_Distribution, MD_Distributor, MD_Format, MD_Medium, MD_MediumFormatCode, and MD_StandardOrderProcess
@@ -31,15 +29,26 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gts</td>
+            <td>http://www.isotc211.org/2005/gts</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gts/gts.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mrd 1.0</h2> Schematron rules for validating instance documents of the mrd 1.0 namespace are in
-      mrd.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mrd 1.0</h2> Schematron rules for validating instance documents of the mrd 1.0 namespace are in mrd.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gts.sch, mcc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mri/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mri/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mri 1.0</h2>
       <p><b>mri.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mri 1.0 namespace or by
-         XML Schema documents importing the mri 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mri namespace,
-         but it does not contain the declaration of any types.
+         in the mri 1.0 namespace or by XML Schema documents importing the mri 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mri namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mri 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mri 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mri 1.0</h2>
       <p><b>identification.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.3. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: DS_AssociationTypeCode, DS_InitiativeTypeCode, MD_AssociatedResource, MD_DataIdentification, AbstractMD_Identification, MD_KeywordClass, MD_KeywordTypeCode, MD_Keywords, MD_RepresentativeFraction, MD_Resolution, MD_TopicCategoryCode, and MD_Usage
@@ -31,6 +29,30 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td>Citation and responsible party information</td>
+            <td>cit</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gts</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gts/gts.xsd</td>
+         </tr>
+         <tr>
+            <td>Geospatial EXtent</td>
+            <td>gex</td>
+            <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/lan/1.0/2014-07-11/lan.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gts</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+         </tr>
+         <tr>
             <td>Language localization</td>
             <td>lan</td>
             <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
@@ -42,10 +64,21 @@
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata for Constraints</td>
+            <td>mco</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2013-06-24</td>
+            <td>../../../cit/1.0/2013-06-24/cit.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata for Maintenance Information</td>
+            <td>mmi</td>
+            <td>http://www.isotc211.org/2005/lan/1.0/2013-06-24</td>
+            <td>../../../lan/1.0/2013-06-24/lan.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mri 1.0</h2> Schematron rules for validating instance documents of the mri 1.0 namespace are in
-      mri.sch. Other schematron rule sets that are required for a complete validation are: lan.sch, and mcc.sch
+      <h2>Schematron Validation Rules for mri 1.0</h2> Schematron rules for validating instance documents of the mri 1.0 namespace are in mri.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gts.sch, lan.sch, mcc.sch, lan.sch, mcc.sch, cit.sch, lan.sch, mcc.sch, gex.sch, mmi.sch, and mco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mrl/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mrl/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mrl 1.0</h2>
       <p><b>mrl.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mrl 1.0 namespace or by
-         XML Schema documents importing the mrl 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mrl namespace,
-         but it does not contain the declaration of any types.
+         in the mrl 1.0 namespace or by XML Schema documents importing the mrl 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mrl namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mrl 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mrl 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mrl 1.0</h2>
       <p><b>lineage.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.5. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: LI_Lineage, LI_ProcessStep, and LI_Source
@@ -34,15 +32,50 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td>Citation and responsible party information</td>
+            <td>cit</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gts</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gts/gts.xsd</td>
+         </tr>
+         <tr>
+            <td>Geospatial EXtent</td>
+            <td>gex</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gts</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata for Resource Identification</td>
+            <td>mri</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata for Reference System</td>
+            <td>mrs</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2013-06-24</td>
+            <td>../../../cit/1.0/2013-06-24/cit.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mrl 1.0</h2> Schematron rules for validating instance documents of the mrl 1.0 namespace are in
-      mrl.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mrl 1.0</h2> Schematron rules for validating instance documents of the mrl 1.0 namespace are in mrl.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gts.sch, mcc.sch, gco.sch, mcc.sch, mcc.sch, cit.sch, mcc.sch, mri.sch, gex.sch, and mrs.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/mrs/1.0/2014-07-11/index.html
+++ b/ISO19115-3/mrs/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mrs 1.0</h2>
       <p><b>mrs.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mrs 1.0 namespace or by
-         XML Schema documents importing the mrs 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mrs namespace,
-         but it does not contain the declaration of any types.
+         in the mrs 1.0 namespace or by XML Schema documents importing the mrs 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mrs namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mrs 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mrs 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mrs 1.0</h2>
       <p><b>referenceSystem.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.8. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_ReferenceSystem, and MD_ReferenceSystemTypeCode
@@ -31,15 +29,20 @@
             <th>Schema Location</th>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for mrs 1.0</h2> Schematron rules for validating instance documents of the mrs 1.0 namespace are in
-      mrs.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch
+      <h2>Schematron Validation Rules for mrs 1.0</h2> Schematron rules for validating instance documents of the mrs 1.0 namespace are in mrs.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch, gco.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/msr/1.0/2014-07-11/index.html
+++ b/ISO19115-3/msr/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for msr 1.0</h2>
       <p><b>msr.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the msr 1.0 namespace or by
-         XML Schema documents importing the msr 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the msr namespace,
-         but it does not contain the declaration of any types.
+         in the msr 1.0 namespace or by XML Schema documents importing the msr 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the msr namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for msr 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for msr 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for msr 1.0</h2>
       <p><b>spatialRepresentation.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.7. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: MD_CellGeometryCode, MD_Dimension, MD_DimensionNameTypeCode, MD_GeometricObjectTypeCode, MD_GeometricObjects, MD_Georectified, MD_Georeferenceable, MD_GridSpatialRepresentation, MD_PixelOrientationCode, MD_TopologyLevelCode, and MD_VectorSpatialRepresentation
@@ -40,15 +38,26 @@
             <td>../../../../ISO19157-2/dqc/1.0/2014-07-11/dqc.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
+         <tr>
+            <td></td>
+            <td>gss</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/2005/gss</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gss/gss.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for msr 1.0</h2> Schematron rules for validating instance documents of the msr 1.0 namespace are in
-      msr.sch. Other schematron rule sets that are required for a complete validation are: dqc.sch, and mcc.sch
+      <h2>Schematron Validation Rules for msr 1.0</h2> Schematron rules for validating instance documents of the msr 1.0 namespace are in msr.sch. Other schematron rule sets that are required for a complete validation are: dqc.sch, mcc.sch, gco.sch, gss.sch, mcc.sch, gco.sch, gss.sch, dqc.sch, and mcc.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19115-3/srv/2.0/2014-07-11/index.html
+++ b/ISO19115-3/srv/2.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for srv 2.0</h2>
       <p><b>srv.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the srv 2.0 namespace or by
-         XML Schema documents importing the srv 2.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the srv namespace,
-         but it does not contain the declaration of any types.
+         in the srv 2.0 namespace or by XML Schema documents importing the srv 2.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the srv namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for srv 2.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for srv 2.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for srv 2.0</h2>
       <p><b>serviceInformation.xsd</b> implements the UML conceptual schema defined in ISO 19115-1, 6.5.14. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: DCPList, SV_CoupledResource, SV_CouplingType, SV_OperationChainMetadata, SV_OperationMetadata, SV_Parameter, SV_ParameterDirection, and SV_ServiceIdentification
@@ -29,6 +27,12 @@
             <th>Standard Prefix</th>
             <th>Namespace Location</th>
             <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
          </tr>
          <tr>
             <td>Metadata Common Classes</td>
@@ -43,9 +47,8 @@
             <td>../../../../ISO19115-3/mri/1.0/2014-07-11/mri.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for srv 2.0</h2> Schematron rules for validating instance documents of the srv 2.0 namespace are in
-      srv.sch. Other schematron rule sets that are required for a complete validation are: mcc.sch, and mri.sch
+      <h2>Schematron Validation Rules for srv 2.0</h2> Schematron rules for validating instance documents of the srv 2.0 namespace are in srv.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, mcc.sch, mri.sch, mcc.sch, and mri.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19135/pre/1.0/2014-07-11/index.html
+++ b/ISO19135/pre/1.0/2014-07-11/index.html
@@ -13,21 +13,32 @@
       </p>
       <h2>XML Schema for pre 1.0</h2>
       <p><b>pre.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the pre 1.0 namespace or by
-         XML Schema documents importing the pre 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the pre namespace,
-         but it does not contain the declaration of any types.
+         in the pre 1.0 namespace or by XML Schema documents importing the pre 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the pre namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for pre 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for pre 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for pre 1.0</h2>
       <p><b>abstract.xsd</b> implements the UML conceptual schema defined in ISO 19135, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: Abstract_Register, and Abstract_RegisterItem
       </p>
-      <h2>No Related XML Namespaces for pre 1.0</h2>
-      <h2>Schematron Validation Rules for pre 1.0</h2> Schematron rules for validating instance documents of the pre 1.0 namespace are in
-      pre.sch. Other schematron rule sets that are required for a complete validation are: 
+      <h2>Related XML Namespaces for pre 1.0</h2> The pre 1.0 namespace imports these other namespaces: 
+      <table border="1" cellpadding="3" cellspacing="3">
+         <tr>
+            <th>Name</th>
+            <th>Standard Prefix</th>
+            <th>Namespace Location</th>
+            <th>Schema Location</th>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+      </table>
+      <h2>Schematron Validation Rules for pre 1.0</h2> Schematron rules for validating instance documents of the pre 1.0 namespace are in pre.sch. Other schematron rule sets that are required for a complete validation are: gco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19135/reg/1.0/2014-07-11/index.html
+++ b/ISO19135/reg/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for reg 1.0</h2>
       <p><b>reg.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the reg 1.0 namespace or by
-         XML Schema documents importing the reg 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the reg namespace,
-         but it does not contain the declaration of any types.
+         in the reg 1.0 namespace or by XML Schema documents importing the reg 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the reg namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for reg 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for reg 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for reg 1.0</h2>
       <p><b>registration.xsd</b> implements the UML conceptual schema defined in ISO 19135, unknown. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: RE_AdditionInformation, RE_AlternativeExpression, RE_AlternativeName, RE_AmendmentInformation, RE_AmendmentType, RE_ClarificationInformation, RE_DecisionStatus, RE_Disposition, RE_FieldOfApplication, RE_ItemClass, RE_ItemStatus, RE_Locale, AbstractRE_ProposalManagementInformation, RE_Reference, RE_ReferenceSource, RE_Register, RE_RegisterItem, RE_RegisterManager, RE_RegisterOwner, RE_SimilarityToSource, RE_SubmittingOrganization, RE_SubregisterDescription, and RE_Version
@@ -39,27 +37,32 @@
             <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
          <tr>
-            <td>Language localization</td>
-            <td>lan</td>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/lan/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/lan/1.0/2014-07-11/lan.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td>Language localization</td>
+            <td>lan</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
-            <td>Procedures for Registration</td>
-            <td>pre</td>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
             <td>http://www.isotc211.org/namespace/pre/1.0/2014-07-11</td>
             <td>../../../../ISO19135/pre/1.0/pre.xsd</td>
          </tr>
+         <tr>
+            <td>Procedures for Registration</td>
+            <td>pre</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
       </table>
-      <h2>Schematron Validation Rules for reg 1.0</h2> Schematron rules for validating instance documents of the reg 1.0 namespace are in
-      reg.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, lan.sch, mcc.sch, and pre.sch
+      <h2>Schematron Validation Rules for reg 1.0</h2> Schematron rules for validating instance documents of the reg 1.0 namespace are in reg.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, lan.sch, mcc.sch, pre.sch, gco.sch, lan.sch, mcc.sch, and pre.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19157-2/dqc/1.0/2014-07-11/index.html
+++ b/ISO19157-2/dqc/1.0/2014-07-11/index.html
@@ -13,13 +13,11 @@
       </p>
       <h2>XML Schema for dqc 1.0</h2>
       <p><b>dqc.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the dqc 1.0 namespace or by
-         XML Schema documents importing the dqc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the dqc namespace,
-         but it does not contain the declaration of any types.
+         in the dqc 1.0 namespace or by XML Schema documents importing the dqc 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the dqc namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for dqc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for dqc 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for dqc 1.0</h2>
       <p><b>abstract.xsd</b> implements the UML conceptual schema defined in ISO 19157, 6.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: Abstract_DataQuality, and Abstract_QualityElement
@@ -35,6 +33,12 @@
          <tr>
             <td>Citation and responsible party information</td>
             <td>cit</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
@@ -51,9 +55,8 @@
             <td>../../../../ISO19115-3/mrd/1.0/2014-07-11/mrd.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for dqc 1.0</h2> Schematron rules for validating instance documents of the dqc 1.0 namespace are in
-      dqc.sch. Other schematron rule sets that are required for a complete validation are: cit.sch, mrc.sch, and mrd.sch
+      <h2>Schematron Validation Rules for dqc 1.0</h2> Schematron rules for validating instance documents of the dqc 1.0 namespace are in dqc.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, cit.sch, mrc.sch, and mrd.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19157-2/dqm/1.0/2014-07-11/index.html
+++ b/ISO19157-2/dqm/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for dqm 1.0</h2>
       <p><b>dqm.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the dqm 1.0 namespace or by
-         XML Schema documents importing the dqm 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the dqm namespace,
-         but it does not contain the declaration of any types.
+         in the dqm 1.0 namespace or by XML Schema documents importing the dqm 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the dqm namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for dqm 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for dqm 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for dqm 1.0</h2>
       <p><b>qualityMeasures.xsd</b> implements the UML conceptual schema defined in ISO 19157, 6.5. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: DQM_BasicMeasure, DQM_Description, DQM_Measure, DQM_MeasureCatalogue, DQM_Parameter, DQM_RegisteredDataQualityBasicMeasure, DQM_RegisteredDataQualityMeasure, DQM_RegisteredDataQualityParameter, DQM_SourceReference, and DQM_ValueStructure
@@ -33,25 +31,36 @@
          <tr>
             <td>CATalogue</td>
             <td>cat</td>
-            <td>http://www.isotc211.org/namespace/cat/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/cat/1.0/2014-07-11/cat.xsd</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
          </tr>
          <tr>
-            <td>Metadata Common Classes</td>
-            <td>mcc</td>
+            <td>Citation and responsible party information</td>
+            <td>cit</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
+            <td>Metadata Common Classes</td>
+            <td>mcc</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Procedures for Registration</td>
             <td>pre</td>
-            <td>http://www.isotc211.org/namespace/pre/1.0/2014-07-11</td>
-            <td>../../../../ISO19135/pre/1.0/2014-07-11/pre.xsd</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for dqm 1.0</h2> Schematron rules for validating instance documents of the dqm 1.0 namespace are in
-      dqm.sch. Other schematron rule sets that are required for a complete validation are: cat.sch, mcc.sch, and pre.sch
+      <h2>Schematron Validation Rules for dqm 1.0</h2> Schematron rules for validating instance documents of the dqm 1.0 namespace are in dqm.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, cit.sch, mcc.sch, gco.sch, cit.sch, mcc.sch, cat.sch, mcc.sch, pre.sch, gco.sch, cat.sch, mcc.sch, and pre.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/ISO19157-2/mdq/1.0/2014-07-11/index.html
+++ b/ISO19157-2/mdq/1.0/2014-07-11/index.html
@@ -11,13 +11,11 @@
       </p>
       <h2>XML Schema for mdq 1.0</h2>
       <p><b>mdq.xsd</b> is the XML Schema document to be referenced by XML documents containing XML elements
-         in the mdq 1.0 namespace or by
-         XML Schema documents importing the mdq 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
-         the mdq namespace,
-         but it does not contain the declaration of any types.
+         in the mdq 1.0 namespace or by XML Schema documents importing the mdq 1.0 namespace. This XML schema includes (indirectly) all the implemented concepts of
+         the mdq namespace, but it does not contain the declaration of any types.
       </p>
-      <p><i>NOTE: The XML Schema for mdq 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations
-            defined in ISO/TS 19115-3.</i></p>
+      <p><i>NOTE: The XML Schema for mdq 1.0 are available <a href="http://isotc211.org/schema">here</a> as part of a zip archive including all the XML Schema Implementations defined in
+            ISO/TS 19115-3.</i></p>
       <h2>Related XML Schema for mdq 1.0</h2>
       <p><b>dataQualityElement.xsd</b> implements the UML conceptual schema defined in ISO 19157, 6.4. It was created using the encoding rules defined in ISO 19118, ISO 19139, and ISO
          19115-3 and contains the following classes: DQ_AbsoluteExternalPositionalAccuracy, DQ_AccuracyOfATimeMeasurement, AbstractDQ_Completeness, DQ_CompletenessCommission, DQ_CompletenessOmission, DQ_ConceptualConsistency, DQ_DataInspection, DQ_DataQuality, DQ_DomainConsistency, AbstractDQ_Element, DQ_FormatConsistency, DQ_GriddedDataPositionalAccuracy, AbstractDQ_LogicalConsistency, DQ_MeasureReference, DQ_NonQuantitativeAttributeCorrectness, AbstractDQ_PositionalAccuracy, DQ_QuantitativeAttributeAccuracy, DQ_RelativeInternalPositionalAccuracy, DQ_StandaloneQualityReportInformation, DQ_TemporalConsistency, AbstractDQ_TemporalQuality, DQ_TemporalValidity, AbstractDQ_ThematicAccuracy, DQ_ThematicClassificationCorrectness, DQ_TopologicalConsistency, and DQ_UsabilityElement
@@ -43,33 +41,56 @@
             <th>Schema Location</th>
          </tr>
          <tr>
+            <td>Citation and responsible party information</td>
+            <td>cit</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
+         </tr>
+         <tr>
             <td>Data Quality Common Classes</td>
             <td>dqc</td>
-            <td>http://www.isotc211.org/namespace/dqc/1.0/2014-07-11</td>
-            <td>../../../../ISO19157-2/dqc/1.0/2014-07-11/dqc.xsd</td>
+            <td>http://www.isotc211.org/namespace/gex/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/gex/1.0/2014-07-11/gex.xsd</td>
+         </tr>
+         <tr>
+            <td></td>
+            <td>gco</td>
+            <td>http://www.isotc211.org/namespace/cit/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/cit/1.0/2014-07-11/cit.xsd</td>
          </tr>
          <tr>
             <td>Geospatial Common eXtension</td>
             <td>gcx</td>
-            <td>http://www.isotc211.org/namespace/gcx/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/gcx/1.0/2014-07-11/gcx.xsd</td>
+            <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
+            <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
+         </tr>
+         <tr>
+            <td>Geospatial EXtent</td>
+            <td>gex</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
          </tr>
          <tr>
             <td>Metadata Common Classes</td>
             <td>mcc</td>
+            <td>http://www.isotc211.org/namespace/dqc/1.0/2014-07-11</td>
+            <td>../../../../ISO19157-2/dqc/1.0/2014-07-11/dqc.xsd</td>
+         </tr>
+         <tr>
+            <td>Metadata for Resource DIstribution</td>
+            <td>mrd</td>
             <td>http://www.isotc211.org/namespace/mcc/1.0/2014-07-11</td>
             <td>../../../../ISO19115-3/mcc/1.0/2014-07-11/mcc.xsd</td>
          </tr>
          <tr>
             <td>Metadata for Resource Identification</td>
             <td>mri</td>
-            <td>http://www.isotc211.org/namespace/mri/1.0/2014-07-11</td>
-            <td>../../../../ISO19115-3/mri/1.0/2014-07-11/mri.xsd</td>
+            <td>http://www.isotc211.org/2005/gco</td>
+            <td>http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd</td>
          </tr>
       </table>
-      <h2>Schematron Validation Rules for mdq 1.0</h2> Schematron rules for validating instance documents of the mdq 1.0 namespace are in
-      mdq.sch. Other schematron rule sets that are required for a complete validation are: dqc.sch, gcx.sch, mcc.sch, and mri.sch
+      <h2>Schematron Validation Rules for mdq 1.0</h2> Schematron rules for validating instance documents of the mdq 1.0 namespace are in mdq.sch. Other schematron rule sets that are required for a complete validation are: gco.sch, gex.sch, cit.sch, mcc.sch, gco.sch, dqc.sch, mcc.sch, gco.sch, mcc.sch, gco.sch, gcx.sch, mcc.sch, mrd.sch, gco.sch, mcc.sch, dqc.sch, gcx.sch, mcc.sch, mri.sch, and gco.sch
       <hr>
-      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T15:27:29.711-06:00</font></p>
+      <p><font size="small" face="italic">Written by writeHTMLFiles Version: 2014-09-23 at 2014-09-23T16:43:45.803-06:00</font></p>
    </body>
 </html>

--- a/resources/namespaceSummary.html
+++ b/resources/namespaceSummary.html
@@ -31,7 +31,7 @@
             <td align="center">Catalog, Code List Item, uom Item, CRS Item</td>
             <td>cat.xsd</td>
             <td>catalogues.xsd, codelistItem.xsd, crsItem.xsd, uomItem.xsd</td>
-            <td>lan</td>
+            <td>lan, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/cit/1.0/2014-07-11/index.html">cit</a></td>
@@ -45,7 +45,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Citation</td>
             <td>cit.xsd</td>
             <td>citation.xsd</td>
-            <td></td>
+            <td>gco, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19157-2/dqc/1.0/2014-07-11/index.html">dqc</a></td>
@@ -61,7 +61,7 @@
             <td align="center">Data Quality</td>
             <td>dqc.xsd</td>
             <td>abstract.xsd</td>
-            <td>cit, mrc, mrd</td>
+            <td>gco, cit, mrc, mrd</td>
          </tr>
          <tr>
             <td><a href="../ISO19157-2/dqm/1.0/2014-07-11/index.html">dqm</a></td>
@@ -75,7 +75,7 @@
             <td align="center">Data Quality</td>
             <td>dqm.xsd</td>
             <td>qualityMeasures.xsd</td>
-            <td>cat, mcc, pre</td>
+            <td>gco, cit, mcc, cat, pre</td>
          </tr>
          <tr>
             <td><a href="../ISO19110/fcc/1.0/2014-07-11/index.html">fcc</a></td>
@@ -91,7 +91,7 @@
             <td align="center"></td>
             <td>fcc.xsd</td>
             <td>abstract.xsd</td>
-            <td></td>
+            <td>gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/gcx/1.0/2014-07-11/index.html">gcx</a></td>
@@ -105,7 +105,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Extended Types</td>
             <td>gcx.xsd</td>
             <td>extendedTypes.xsd</td>
-            <td></td>
+            <td>gco, xlink, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/gex/1.0/2014-07-11/index.html">gex</a></td>
@@ -121,7 +121,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Extent</td>
             <td>gex.xsd</td>
             <td>extent.xsd</td>
-            <td>mcc, rce</td>
+            <td>gco, gss, gts, mcc, rce</td>
          </tr>
          <tr>
             <td><a href="../ISO19110/gfc/1.1/2014-07-11/index.html">gfc</a></td>
@@ -142,7 +142,7 @@
             <td align="center"></td>
             <td>gfc.xsd</td>
             <td>featureCatalogue.xsd</td>
-            <td>cit, fcc, lan, mcc</td>
+            <td>gco, fcc, lan, mcc, 3.2, cit</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/lan/1.0/2014-07-11/index.html">lan</a></td>
@@ -156,7 +156,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Language</td>
             <td>lan.xsd</td>
             <td>language.xsd</td>
-            <td>cit</td>
+            <td>cit, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mas/1.0/2014-07-11/index.html">mas</a></td>
@@ -170,7 +170,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Application Schema</td>
             <td>mas.xsd</td>
             <td>applicationSchema.xsd</td>
-            <td>cit, mcc</td>
+            <td>gco, mcc, cit</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mcc/1.0/2014-07-11/index.html">mcc</a></td>
@@ -186,7 +186,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt;</td>
             <td>mcc.xsd</td>
             <td>AbstractCommonClasses.xsd, commonClasses.xsd</td>
-            <td></td>
+            <td>gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mco/1.0/2014-07-11/index.html">mco</a></td>
@@ -200,7 +200,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Constraints</td>
             <td>mco.xsd</td>
             <td>constraints.xsd</td>
-            <td>mcc</td>
+            <td>gco, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/md1/1.0/2014-07-11/index.html">md1</a></td>
@@ -249,7 +249,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Metadata Application</td>
             <td>mda.xsd</td>
             <td>metadataApplication.xsd</td>
-            <td>md2</td>
+            <td>md2, gco, mdb</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mdb/1.0/2014-07-11/index.html">mdb</a></td>
@@ -265,7 +265,7 @@
             <td align="center"></td>
             <td>mdb.xsd</td>
             <td>metadataBase.xsd</td>
-            <td>cit, dqc, lan, mcc, mri</td>
+            <td>cit, dqc, lan, mcc, mri, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19157-2/mdq/1.0/2014-07-11/index.html">mdq</a></td>
@@ -281,7 +281,7 @@
             <td>dataQualityElement.xsd, dataQualityEvaluation.xsd, dataQualityImagery.xsd, dataQualityResult.xsd,
                metaquality.xsd
             </td>
-            <td>dqc, gcx, mcc, mri</td>
+            <td>gco, gex, cit, mcc, dqc, gcx, mrd, mri</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mds/1.0/2014-07-11/index.html">mds</a></td>
@@ -318,7 +318,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Metadata-based Data Transfers</td>
             <td>mdt.xsd</td>
             <td>metadataTransfer.xsd</td>
-            <td>cat, gcx, mda</td>
+            <td>cat, gcx, mda, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mex/1.0/2014-07-11/index.html">mex</a></td>
@@ -332,7 +332,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Metadata Extension</td>
             <td>mex.xsd</td>
             <td>metadataExtension.xsd</td>
-            <td>mcc</td>
+            <td>gco, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mmi/1.0/2014-07-11/index.html">mmi</a></td>
@@ -346,7 +346,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Maintenance</td>
             <td>mmi.xsd</td>
             <td>maintenance.xsd</td>
-            <td>mcc</td>
+            <td>gco, gts, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mpc/1.0/2014-07-11/index.html">mpc</a></td>
@@ -360,7 +360,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Portrayal Catalog</td>
             <td>mpc.xsd</td>
             <td>portrayalCatalogue.xsd</td>
-            <td>mcc</td>
+            <td>mcc, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mrc/1.0/2014-07-11/index.html">mrc</a></td>
@@ -374,7 +374,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Resource Content</td>
             <td>mrc.xsd</td>
             <td>content.xsd, contentInformationImagery.xsd</td>
-            <td>fcc, lan, mcc</td>
+            <td>gco, fcc, lan, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mrd/1.0/2014-07-11/index.html">mrd</a></td>
@@ -388,7 +388,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Distribution Information</td>
             <td>mrd.xsd</td>
             <td>distribution.xsd</td>
-            <td>mcc</td>
+            <td>gco, gts, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mri/1.0/2014-07-11/index.html">mri</a></td>
@@ -402,7 +402,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Identification Information</td>
             <td>mri.xsd</td>
             <td>identification.xsd</td>
-            <td>lan, mcc</td>
+            <td>gco, gts, lan, mcc, cit, gex, mmi, mco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mrl/1.0/2014-07-11/index.html">mrl</a></td>
@@ -416,7 +416,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt;</td>
             <td>mrl.xsd</td>
             <td>lineage.xsd, lineageImagery.xsd</td>
-            <td>mcc</td>
+            <td>gco, gts, mcc, cit, mri, gex, mrs</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/mrs/1.0/2014-07-11/index.html">mrs</a></td>
@@ -430,7 +430,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Reference System</td>
             <td>mrs.xsd</td>
             <td>referenceSystem.xsd</td>
-            <td>mcc</td>
+            <td>mcc, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/msr/1.0/2014-07-11/index.html">msr</a></td>
@@ -444,7 +444,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Spatial Representation</td>
             <td>msr.xsd</td>
             <td>spatialRepresentation.xsd, spatialRepresentationImagery.xsd</td>
-            <td>dqc, mcc</td>
+            <td>dqc, mcc, gco, gss</td>
          </tr>
          <tr>
             <td><a href="../ISO19135/pre/1.0/2014-07-11/index.html">pre</a></td>
@@ -460,7 +460,7 @@
             <td align="center"></td>
             <td>pre.xsd</td>
             <td>abstract.xsd</td>
-            <td></td>
+            <td>gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19111/rbc/1.0/2014-07-11/index.html">rbc</a></td>
@@ -483,7 +483,7 @@
             <td>coordinateOperations.xsd, coordinateReferenceSystems.xsd, coordinateSystems.xsd, datums.xsd,
                parametricValues.xsd, temporalReferenceSystems.xsd
             </td>
-            <td>dqc, mcc, rce</td>
+            <td>gco, dqc, mcc, rce, 3.2</td>
          </tr>
          <tr>
             <td><a href="../ISO19111/rce/1.0/2014-07-11/index.html">rce</a></td>
@@ -499,7 +499,7 @@
             <td align="center"></td>
             <td>rce.xsd</td>
             <td>abstractClasses.xsd</td>
-            <td>mcc</td>
+            <td>gco, mcc</td>
          </tr>
          <tr>
             <td><a href="../ISO19135/reg/1.0/2014-07-11/index.html">reg</a></td>
@@ -515,7 +515,7 @@
             <td align="center"></td>
             <td>reg.xsd</td>
             <td>registration.xsd</td>
-            <td>cit, lan, mcc, pre</td>
+            <td>cit, lan, mcc, pre, gco</td>
          </tr>
          <tr>
             <td><a href="../ISO19115-3/srv/2.0/2014-07-11/index.html">srv</a></td>
@@ -529,7 +529,7 @@
             <td align="center">&lt;&lt;Leaf&gt;&gt; Services</td>
             <td>srv.xsd</td>
             <td>serviceInformation.xsd</td>
-            <td>mcc, mri</td>
+            <td>gco, mcc, mri</td>
          </tr>
       </table>
    </body>


### PR DESCRIPTION
Peter Parslow pointed out that I was missing some imported namespaces.
This was due to the fact that I was only searching prefix.xsd for
imports rather than all schemas in the directory. I fixed this for both
the table and the namespace files.
