### PR TITLE
Fixed the class order in 2010-07-30

### DIFF
--- a/ISO19115-2/gmi/1.0/2010-07-30/acquisitionInformation.xsd
+++ b/ISO19115-2/gmi/1.0/2010-07-30/acquisitionInformation.xsd
@@ -12,117 +12,28 @@
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
 	<!-- ================================== Classes ================================= -->
-	<xs:complexType name="MI_Requirement_Type">
+	<xs:complexType name="MI_Instrument_Type">
 		<xs:annotation>
-			<xs:documentation>Description: requirement to be satisfied by the planned data acquisition - shortName: Requirement</xs:documentation>
+			<xs:documentation>Description: Designations for the measuring instruments - FGDC: Platform_and_Instrument_Identification - shortName: PltfrmInstId</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="citation" type="gmd:CI_Citation_PropertyType" minOccurs="0"/>
+					<xs:element name="citation" type="gmd:CI_Citation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType"/>
-					<xs:element name="requestor" type="gmd:CI_ResponsibleParty_PropertyType" maxOccurs="unbounded"/>
-					<xs:element name="recipient" type="gmd:CI_ResponsibleParty_PropertyType" maxOccurs="unbounded"/>
-					<xs:element name="priority" type="gmi:MI_PriorityCode_PropertyType"/>
-					<xs:element name="requestedDate" type="gmi:MI_RequestedDate_PropertyType"/>
-					<xs:element name="expiryDate" type="gco:DateTime_PropertyType"/>
-					<xs:element name="satisifiedPlan" type="gmi:MI_Plan_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="type" type="gco:CharacterString_PropertyType"/>
+					<xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+					<xs:element name="mountedOn" type="gmi:MI_Platform_PropertyType" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="MI_Requirement" type="gmi:MI_Requirement_Type"/>
+	<xs:element name="MI_Instrument" type="gmi:MI_Instrument_Type"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_Requirement_PropertyType">
+	<xs:complexType name="MI_Instrument_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_Requirement" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MI_Objective_Type">
-		<xs:annotation>
-			<xs:documentation>Description: Describes the characteristics, spatial and temporal extent of the intended object to be observed  - shortName: TargetId</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType" maxOccurs="unbounded"/>
-					<xs:element name="priority" type="gco:CharacterString_PropertyType" minOccurs="0"/>
-					<xs:element name="type" type="gmi:MI_ObjectiveTypeCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="function" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="extent" type="gmd:EX_Extent_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="pass" type="gmi:MI_PlatformPass_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="sensingInstrument" type="gmi:MI_Instrument_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="objectiveOccurrence" type="gmi:MI_Event_PropertyType" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_Objective" type="gmi:MI_Objective_Type"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_Objective_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_Objective" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MI_AcquisitionInformation_Type">
-		<xs:annotation>
-			<xs:documentation>Description: Designations for the measuring instruments and their bands, the platform carrying them, and the mission to which the data contributes - FGDC: Platform_and_Instrument_Identification, Mission_Information - shortName: PltfrmInstId</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="acquisitionRequirement" type="gmi:MI_Requirement_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="objective" type="gmi:MI_Objective_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="instrument" type="gmi:MI_Instrument_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="acquisitionPlan" type="gmi:MI_Plan_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="operation" type="gmi:MI_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="platform" type="gmi:MI_Platform_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="environmentalConditions" type="gmi:MI_EnvironmentalRecord_PropertyType" minOccurs="0"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_AcquisitionInformation" type="gmi:MI_AcquisitionInformation_Type"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_AcquisitionInformation_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_AcquisitionInformation" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MI_Plan_Type">
-		<xs:annotation>
-			<xs:documentation>Description: Designations for the planning information related to meeting requirements - shortName: PlanId</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="type" type="gmi:MI_GeometryTypeCode_PropertyType" minOccurs="0"/>
-					<xs:element name="status" type="gmd:MD_ProgressCode_PropertyType"/>
-					<xs:element name="citation" type="gmd:CI_Citation_PropertyType"/>
-					<xs:element name="satisfiedRequirement" type="gmi:MI_Requirement_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="operation" type="gmi:MI_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_Plan" type="gmi:MI_Plan_Type"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_Plan_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_Plan" minOccurs="0"/>
+			<xs:element ref="gmi:MI_Instrument" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
@@ -160,33 +71,6 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
-	<xs:complexType name="MI_Instrument_Type">
-		<xs:annotation>
-			<xs:documentation>Description: Designations for the measuring instruments - FGDC: Platform_and_Instrument_Identification - shortName: PltfrmInstId</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="citation" type="gmd:CI_Citation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType"/>
-					<xs:element name="type" type="gco:CharacterString_PropertyType"/>
-					<xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
-					<xs:element name="mountedOn" type="gmi:MI_Platform_PropertyType" minOccurs="0"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_Instrument" type="gmi:MI_Instrument_Type"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_Instrument_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_Instrument" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
 	<xs:complexType name="MI_Platform_Type">
 		<xs:annotation>
 			<xs:documentation>Description: Designations for the platform used to acquire the dataset - shortName: PltfrmId</xs:documentation>
@@ -214,29 +98,35 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
-	<xs:complexType name="MI_EnvironmentalRecord_Type">
+	<xs:complexType name="MI_AcquisitionInformation_Type">
+		<xs:annotation>
+			<xs:documentation>Description: Designations for the measuring instruments and their bands, the platform carrying them, and the mission to which the data contributes - FGDC: Platform_and_Instrument_Identification, Mission_Information - shortName: PltfrmInstId</xs:documentation>
+		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="averageAirTemperature" type="gco:Real_PropertyType"/>
-					<xs:element name="maxRelativeHumidity" type="gco:Real_PropertyType"/>
-					<xs:element name="maxAltitude" type="gco:Real_PropertyType"/>
-					<xs:element name="meterologicalConditions" type="gco:CharacterString_PropertyType"/>
+					<xs:element name="acquisitionRequirement" type="gmi:MI_Requirement_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="objective" type="gmi:MI_Objective_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="instrument" type="gmi:MI_Instrument_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="acquisitionPlan" type="gmi:MI_Plan_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="operation" type="gmi:MI_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="platform" type="gmi:MI_Platform_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="environmentalConditions" type="gmi:MI_EnvironmentalRecord_PropertyType" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="MI_EnvironmentalRecord" type="gmi:MI_EnvironmentalRecord_Type"/>
+	<xs:element name="MI_AcquisitionInformation" type="gmi:MI_AcquisitionInformation_Type"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_EnvironmentalRecord_PropertyType">
+	<xs:complexType name="MI_AcquisitionInformation_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_EnvironmentalRecord" minOccurs="0"/>
+			<xs:element ref="gmi:MI_AcquisitionInformation" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
-	<!-- =========================================================================== -->
+	<!-- =========================================================================== -->	
 	<xs:complexType name="MI_Event_Type">
 		<xs:annotation>
 			<xs:documentation>Description: identification of a significant collection point within an operation - shortName: Event</xs:documentation>
@@ -266,26 +156,32 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MI_RequestedDate_Type">
+	<!-- =========================================================================== -->	
+	<xs:complexType name="MI_Requirement_Type">
 		<xs:annotation>
-			<xs:documentation>Description: range of date validity - shortName: ReqstDate</xs:documentation>
+			<xs:documentation>Description: requirement to be satisfied by the planned data acquisition - shortName: Requirement</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="requestedDateOfCollection" type="gco:DateTime_PropertyType"/>
-					<xs:element name="latestAcceptableDate" type="gco:DateTime_PropertyType"/>
+					<xs:element name="citation" type="gmd:CI_Citation_PropertyType" minOccurs="0"/>
+					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType"/>
+					<xs:element name="requestor" type="gmd:CI_ResponsibleParty_PropertyType" maxOccurs="unbounded"/>
+					<xs:element name="recipient" type="gmd:CI_ResponsibleParty_PropertyType" maxOccurs="unbounded"/>
+					<xs:element name="priority" type="gmi:MI_PriorityCode_PropertyType"/>
+					<xs:element name="requestedDate" type="gmi:MI_RequestedDate_PropertyType"/>
+					<xs:element name="expiryDate" type="gco:DateTime_PropertyType"/>
+					<xs:element name="satisifiedPlan" type="gmi:MI_Plan_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="MI_RequestedDate" type="gmi:MI_RequestedDate_Type"/>
+	<xs:element name="MI_Requirement" type="gmi:MI_Requirement_Type"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_RequestedDate_PropertyType">
+	<xs:complexType name="MI_Requirement_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_RequestedDate" minOccurs="0"/>
+			<xs:element ref="gmi:MI_Requirement" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
@@ -315,33 +211,104 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
+	<!-- =========================================================================== -->	
+	<xs:complexType name="MI_Objective_Type">
+		<xs:annotation>
+			<xs:documentation>Description: Describes the characteristics, spatial and temporal extent of the intended object to be observed  - shortName: TargetId</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType" maxOccurs="unbounded"/>
+					<xs:element name="priority" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+					<xs:element name="type" type="gmi:MI_ObjectiveTypeCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="function" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="extent" type="gmd:EX_Extent_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="pass" type="gmi:MI_PlatformPass_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="sensingInstrument" type="gmi:MI_Instrument_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="objectiveOccurrence" type="gmi:MI_Event_PropertyType" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_Objective" type="gmi:MI_Objective_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_Objective_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_Objective" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<xs:complexType name="MI_Plan_Type">
+		<xs:annotation>
+			<xs:documentation>Description: Designations for the planning information related to meeting requirements - shortName: PlanId</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="type" type="gmi:MI_GeometryTypeCode_PropertyType" minOccurs="0"/>
+					<xs:element name="status" type="gmd:MD_ProgressCode_PropertyType"/>
+					<xs:element name="citation" type="gmd:CI_Citation_PropertyType"/>
+					<xs:element name="satisfiedRequirement" type="gmi:MI_Requirement_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="operation" type="gmi:MI_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_Plan" type="gmi:MI_Plan_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_Plan_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_Plan" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<xs:complexType name="MI_RequestedDate_Type">
+		<xs:annotation>
+			<xs:documentation>Description: range of date validity - shortName: ReqstDate</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="requestedDateOfCollection" type="gco:DateTime_PropertyType"/>
+					<xs:element name="latestAcceptableDate" type="gco:DateTime_PropertyType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_RequestedDate" type="gmi:MI_RequestedDate_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_RequestedDate_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_RequestedDate" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
 	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
-	<xs:element name="MI_SequenceCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="MI_SensorTypeCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_SequenceCode_PropertyType">
+	<xs:complexType name="MI_SensorTypeCode_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_SequenceCode" minOccurs="0"/>
+			<xs:element ref="gmi:MI_SensorTypeCode" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
-	<xs:element name="MI_TriggerCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="MI_ContextCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_TriggerCode_PropertyType">
+	<xs:complexType name="MI_ContextCode_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_TriggerCode" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<!-- ........................................................................ -->
-	<xs:element name="MI_PriorityCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_PriorityCode_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_PriorityCode" minOccurs="0"/>
+			<xs:element ref="gmi:MI_ContextCode" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
@@ -357,11 +324,31 @@
 	</xs:complexType>
 	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
-	<xs:element name="MI_SensorTypeCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<xs:element name="MI_TriggerCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MI_SensorTypeCode_PropertyType">
+	<xs:complexType name="MI_TriggerCode_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MI_SensorTypeCode" minOccurs="0"/>
+			<xs:element ref="gmi:MI_TriggerCode" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<!-- ........................................................................ -->
+	<xs:element name="MI_SequenceCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_SequenceCode_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_SequenceCode" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<!-- ........................................................................ -->
+	<xs:element name="MI_PriorityCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_PriorityCode_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_PriorityCode" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
@@ -374,6 +361,29 @@
 			<xs:element ref="gmi:MI_ObjectiveTypeCode" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>	
+	<!-- =========================================================================== -->
+	<xs:complexType name="MI_EnvironmentalRecord_Type">
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="averageAirTemperature" type="gco:Real_PropertyType"/>
+					<xs:element name="maxRelativeHumidity" type="gco:Real_PropertyType"/>
+					<xs:element name="maxAltitude" type="gco:Real_PropertyType"/>
+					<xs:element name="meterologicalConditions" type="gco:CharacterString_PropertyType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_EnvironmentalRecord" type="gmi:MI_EnvironmentalRecord_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_EnvironmentalRecord_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_EnvironmentalRecord" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
@@ -382,16 +392,6 @@
 	<xs:complexType name="MI_OperationTypeCode_PropertyType">
 		<xs:sequence>
 			<xs:element ref="gmi:MI_OperationTypeCode" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<!-- ........................................................................ -->
-	<xs:element name="MI_ContextCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_ContextCode_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_ContextCode" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>

--- a/ISO19115-2/gmi/1.0/2010-07-30/contentInformation.xsd
+++ b/ISO19115-2/gmi/1.0/2010-07-30/contentInformation.xsd
@@ -9,32 +9,8 @@
 	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
-	<!-- ================================== Classes ================================= -->
-	<xs:complexType name="MI_RangeElementDescription_Type">
-		<xs:annotation>
-			<xs:documentation>Description: description of specific range elements - shortName: RgEltDesc</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="name" type="gco:CharacterString_PropertyType"/>
-					<xs:element name="definition" type="gco:CharacterString_PropertyType"/>
-					<xs:element name="rangeElement" type="gco:Record_PropertyType" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_RangeElementDescription" type="gmi:MI_RangeElementDescription_Type"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_RangeElementDescription_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_RangeElementDescription" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
 	<!-- =========================================================================== -->
+	<!-- ================================== Classes ================================= -->
 	<xs:complexType name="MI_Band_Type">
 		<xs:annotation>
 			<xs:documentation>Description: extensions to electromagnetic spectrum wavelength description - shortName: BandExt</xs:documentation>
@@ -108,6 +84,41 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
+	<xs:complexType name="MI_RangeElementDescription_Type">
+		<xs:annotation>
+			<xs:documentation>Description: description of specific range elements - shortName: RgEltDesc</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="name" type="gco:CharacterString_PropertyType"/>
+					<xs:element name="definition" type="gco:CharacterString_PropertyType"/>
+					<xs:element name="rangeElement" type="gco:Record_PropertyType" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_RangeElementDescription" type="gmi:MI_RangeElementDescription_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_RangeElementDescription_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_RangeElementDescription" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<!-- ........................................................................ -->
+	<xs:element name="MI_BandDefinition" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_BandDefinition_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_BandDefinition" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
 	<!-- ........................................................................ -->
 	<xs:element name="MI_PolarisationOrientationCode" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
 	<!-- ........................................................................ -->
@@ -124,16 +135,6 @@
 	<xs:complexType name="MI_TransferFunctionTypeCode_PropertyType">
 		<xs:sequence>
 			<xs:element ref="gmi:MI_TransferFunctionTypeCode" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<!-- ........................................................................ -->
-	<xs:element name="MI_BandDefinition" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_BandDefinition_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_BandDefinition" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>

--- a/ISO19115-2/gmi/1.0/2010-07-30/dataQualityInformation.xsd
+++ b/ISO19115-2/gmi/1.0/2010-07-30/dataQualityInformation.xsd
@@ -11,46 +11,25 @@
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
 	<!-- ================================== Classes ================================= -->
-	<xs:complexType name="LE_ProcessStep_Type">
+	<xs:complexType name="LE_Algorithm_Type">
 		<xs:annotation>
-			<xs:documentation>Description: Information about an event or transformation in the life of the dataset including details of the algorithm and software used for processing - FGDC:  - shortName: DetailProcStep</xs:documentation>
+			<xs:documentation>Description: Details of the methodology by which geographic information was derived from the instrument readings - FGDC: Algorithm_Information - shortName: Algorithm</xs:documentation>
 		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gmd:LI_ProcessStep_Type">
-				<xs:sequence>
-					<xs:element name="output" type="gmi:LE_Source_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="report" type="gmi:LE_ProcessStepReport_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="processingInformation" type="gmi:LE_Processing_PropertyType" minOccurs="0"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="LE_ProcessStep" type="gmi:LE_ProcessStep_Type" substitutionGroup="gmd:LI_ProcessStep"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="LE_ProcessStep_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:LE_ProcessStep" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MX_DataFile_Type">
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
 				<xs:sequence>
-					<xs:element name="fileFormat" type="gmd:MD_Format_PropertyType"/>
+					<xs:element name="citation" type="gmd:CI_Citation_PropertyType"/>
+					<xs:element name="description" type="gco:CharacterString_PropertyType"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="MX_DataFile" type="gmi:MX_DataFile_Type"/>
+	<xs:element name="LE_Algorithm" type="gmi:LE_Algorithm_Type"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="MX_DataFile_PropertyType">
+	<xs:complexType name="LE_Algorithm_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:MX_DataFile" minOccurs="0"/>
+			<xs:element ref="gmi:LE_Algorithm" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
@@ -84,28 +63,50 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
-	<xs:complexType name="QE_CoverageResult_Type">
+	<xs:complexType name="LE_Source_Type">
 		<xs:annotation>
-			<xs:documentation>Description: Result of a data quality measure organising the measured values as a coverage - shortName: CoverageResult</xs:documentation>
+			<xs:documentation>Description: information on source of data sets for processing step - shortName: SrcDataset</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="gmd:AbstractDQ_Result_Type">
+			<xs:extension base="gmd:LI_Source_Type">
 				<xs:sequence>
-					<xs:element name="spatialRepresentationType" type="gmd:MD_SpatialRepresentationTypeCode_PropertyType"/>
-					<xs:element name="resultSpatialRepresentation" type="gmd:MD_SpatialRepresentation_PropertyType"/>
-					<xs:element name="resultContentDescription" type="gmd:MD_CoverageDescription_PropertyType"/>
-					<xs:element name="resultFormat" type="gmd:MD_Format_PropertyType"/>
-					<xs:element name="resultFile" type="gmi:MX_DataFile_PropertyType"/>
+					<xs:element name="processedLevel" type="gmd:MD_Identifier_PropertyType" minOccurs="0"/>
+					<xs:element name="resolution" type="gmi:LE_NominalResolution_PropertyType" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="QE_CoverageResult" type="gmi:QE_CoverageResult_Type" substitutionGroup="gmd:AbstractDQ_Result"/>
+	<xs:element name="LE_Source" type="gmi:LE_Source_Type" substitutionGroup="gmd:LI_Source"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="QE_CoverageResult_PropertyType">
+	<xs:complexType name="LE_Source_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:QE_CoverageResult" minOccurs="0"/>
+			<xs:element ref="gmi:LE_Source" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->	
+	<xs:complexType name="LE_ProcessStep_Type">
+		<xs:annotation>
+			<xs:documentation>Description: Information about an event or transformation in the life of the dataset including details of the algorithm and software used for processing - FGDC:  - shortName: DetailProcStep</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gmd:LI_ProcessStep_Type">
+				<xs:sequence>
+					<xs:element name="output" type="gmi:LE_Source_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="report" type="gmi:LE_ProcessStepReport_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="processingInformation" type="gmi:LE_Processing_PropertyType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="LE_ProcessStep" type="gmi:LE_ProcessStep_Type" substitutionGroup="gmd:LI_ProcessStep"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="LE_ProcessStep_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:LE_ProcessStep" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
@@ -136,49 +137,28 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
-	<xs:complexType name="LE_Algorithm_Type">
+	<xs:complexType name="QE_CoverageResult_Type">
 		<xs:annotation>
-			<xs:documentation>Description: Details of the methodology by which geographic information was derived from the instrument readings - FGDC: Algorithm_Information - shortName: Algorithm</xs:documentation>
+			<xs:documentation>Description: Result of a data quality measure organising the measured values as a coverage - shortName: CoverageResult</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
+			<xs:extension base="gmd:AbstractDQ_Result_Type">
 				<xs:sequence>
-					<xs:element name="citation" type="gmd:CI_Citation_PropertyType"/>
-					<xs:element name="description" type="gco:CharacterString_PropertyType"/>
+					<xs:element name="spatialRepresentationType" type="gmd:MD_SpatialRepresentationTypeCode_PropertyType"/>
+					<xs:element name="resultSpatialRepresentation" type="gmd:MD_SpatialRepresentation_PropertyType"/>
+					<xs:element name="resultContentDescription" type="gmd:MD_CoverageDescription_PropertyType"/>
+					<xs:element name="resultFormat" type="gmd:MD_Format_PropertyType"/>
+					<xs:element name="resultFile" type="gmi:MX_DataFile_PropertyType"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ........................................................................ -->
-	<xs:element name="LE_Algorithm" type="gmi:LE_Algorithm_Type"/>
+	<xs:element name="QE_CoverageResult" type="gmi:QE_CoverageResult_Type" substitutionGroup="gmd:AbstractDQ_Result"/>
 	<!-- ........................................................................ -->
-	<xs:complexType name="LE_Algorithm_PropertyType">
+	<xs:complexType name="QE_CoverageResult_PropertyType">
 		<xs:sequence>
-			<xs:element ref="gmi:LE_Algorithm" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="LE_Source_Type">
-		<xs:annotation>
-			<xs:documentation>Description: information on source of data sets for processing step - shortName: SrcDataset</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gmd:LI_Source_Type">
-				<xs:sequence>
-					<xs:element name="processedLevel" type="gmd:MD_Identifier_PropertyType" minOccurs="0"/>
-					<xs:element name="resolution" type="gmi:LE_NominalResolution_PropertyType" minOccurs="0"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="LE_Source" type="gmi:LE_Source_Type" substitutionGroup="gmd:LI_Source"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="LE_Source_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:LE_Source" minOccurs="0"/>
+			<xs:element ref="gmi:QE_CoverageResult" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
@@ -219,6 +199,26 @@
 		<xs:sequence>
 			<xs:element ref="gmi:LE_NominalResolution" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
+	<xs:complexType name="MX_DataFile_Type">
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="fileFormat" type="gmd:MD_Format_PropertyType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MX_DataFile" type="gmi:MX_DataFile_Type"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MX_DataFile_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MX_DataFile" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->

--- a/ISO19115-2/gmi/1.0/2010-07-30/spatialRepresentationInformation.xsd
+++ b/ISO19115-2/gmi/1.0/2010-07-30/spatialRepresentationInformation.xsd
@@ -36,6 +36,30 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
+	<xs:complexType name="MI_Georectified_Type">
+		<xs:annotation>
+			<xs:documentation>Description: extends georectified grid description to include associated checkpoints - shortName: IGeorect</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gmd:MD_Georectified_Type">
+				<xs:sequence>
+					<xs:element name="checkPoint" type="gmi:MI_GCP_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="geolocationIdentification" type="gmi:MI_GCPCollection_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="MI_Georectified" type="gmi:MI_Georectified_Type" substitutionGroup="gmd:MD_Georectified"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_Georectified_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:MI_Georectified" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>
+	<!-- =========================================================================== -->
 	<xs:complexType name="MI_GCP_Type">
 		<xs:complexContent>
 			<xs:extension base="gco:AbstractObject_Type">
@@ -56,6 +80,26 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
+	<!-- =========================================================================== -->
+	<xs:complexType name="AbstractMI_GeolocationInformation_Type" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="gco:AbstractObject_Type">
+				<xs:sequence>
+					<xs:element name="qualityInfo" type="gmd:DQ_DataQuality_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ........................................................................ -->
+	<xs:element name="AbstractMI_GeolocationInformation" type="gmi:AbstractMI_GeolocationInformation_Type" abstract="true"/>
+	<!-- ........................................................................ -->
+	<xs:complexType name="MI_GeolocationInformation_PropertyType">
+		<xs:sequence>
+			<xs:element ref="gmi:AbstractMI_GeolocationInformation" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="gco:ObjectReference"/>
+		<xs:attribute ref="gco:nilReason"/>
+	</xs:complexType>	
 	<!-- =========================================================================== -->
 	<xs:complexType name="MI_GCPCollection_Type">
 		<xs:complexContent>
@@ -80,49 +124,6 @@
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
 	<!-- =========================================================================== -->
-	<xs:complexType name="AbstractMI_GeolocationInformation_Type" abstract="true">
-		<xs:complexContent>
-			<xs:extension base="gco:AbstractObject_Type">
-				<xs:sequence>
-					<xs:element name="qualityInfo" type="gmd:DQ_DataQuality_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="AbstractMI_GeolocationInformation" type="gmi:AbstractMI_GeolocationInformation_Type" abstract="true"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_GeolocationInformation_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:AbstractMI_GeolocationInformation" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
-	<!-- =========================================================================== -->
-	<xs:complexType name="MI_Georectified_Type">
-		<xs:annotation>
-			<xs:documentation>Description: extends georectified grid description to include associated checkpoints - shortName: IGeorect</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="gmd:MD_Georectified_Type">
-				<xs:sequence>
-					<xs:element name="checkPoint" type="gmi:MI_GCP_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="geolocationIdentification" type="gmi:MI_GCPCollection_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- ........................................................................ -->
-	<xs:element name="MI_Georectified" type="gmi:MI_Georectified_Type" substitutionGroup="gmd:MD_Georectified"/>
-	<!-- ........................................................................ -->
-	<xs:complexType name="MI_Georectified_PropertyType">
-		<xs:sequence>
-			<xs:element ref="gmi:MI_Georectified" minOccurs="0"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gco:ObjectReference"/>
-		<xs:attribute ref="gco:nilReason"/>
-	</xs:complexType>
 	<!--==XCGE: gml:DirectPosition==-->
 	<!-- ........................................................................ -->
 	<xs:complexType name="DirectPosition_PropertyType">
@@ -132,6 +133,4 @@
 		<xs:attributeGroup ref="gco:ObjectReference"/>
 		<xs:attribute ref="gco:nilReason"/>
 	</xs:complexType>
-	<!-- =========================================================================== -->
-	<!-- =========================================================================== -->
 </xs:schema>


### PR DESCRIPTION
The schemas that were generated on 2010-07-30 had very different class
orders than the existing NGDC schemas. This made it difficult to fit
the new schemas into the git repository because most of the differences
were not important. This branch fixed the order of the classes so that
the more critical differences could be easily identified and examined.
