### PR TITLE
Schematron / Add multilingual using diagnostics and report successful assertions

### DIFF
--- a/ISO19115-3/mdb/1.0/2014-07-11/metadata-base-sch-test.xml
+++ b/ISO19115-3/mdb/1.0/2014-07-11/metadata-base-sch-test.xml
@@ -33,7 +33,8 @@
    <mdb:metadataScope>
       <mdb:MD_MetadataScope>
          <mdb:resourceScope>
-            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" codeListValue="AnyURI">/*/gmd:hierarchyLevel/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="AnyURI1">/*/gmd:hierarchyLevel/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
          </mdb:resourceScope>
          <!-- Invalid for conf.metadata-base-instance.scope-name
           mdb:name>
@@ -44,9 +45,62 @@
    <mdb:metadataScope>
       <mdb:MD_MetadataScope>
          <mdb:resourceScope>
-            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" codeListValue="anyValidURI">/*/gmd:hierarchyLevel.2/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="AnyURI2">/*/gmd:hierarchyLevel/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
          </mdb:resourceScope>
          <mdb:name>
+            <!-- Invalid for conf.metadata-base-instance.scope-name
+               <gco:CharacterString>/*/gmd:hierarchyLevelName/gco:CharacterString</gco:CharacterString>
+               -->
+         </mdb:name>
+      </mdb:MD_MetadataScope>
+   </mdb:metadataScope>
+   <mdb:metadataScope>
+      <mdb:MD_MetadataScope>
+         <mdb:resourceScope>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="AnyURI3">/*/gmd:hierarchyLevel/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+         </mdb:resourceScope>
+         <mdb:name>
+            <!-- Invalid for conf.metadata-base-instance.scope-name -->
+            <gco:CharacterString></gco:CharacterString>
+         </mdb:name>
+      </mdb:MD_MetadataScope>
+   </mdb:metadataScope>
+   <mdb:metadataScope>
+      <mdb:MD_MetadataScope>
+         <mdb:resourceScope>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="AnyURI4">/*/gmd:hierarchyLevel/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+         </mdb:resourceScope>
+         <!-- Valid for conf.metadata-base-instance.scope-name due to nilReason -->
+         <mdb:name gco:nilReason="unknown">
+            <gco:CharacterString></gco:CharacterString>
+         </mdb:name>
+      </mdb:MD_MetadataScope>
+   </mdb:metadataScope>
+   <mdb:metadataScope>
+      <mdb:MD_MetadataScope>
+         <mdb:resourceScope>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="anyValidURI5">/*/gmd:hierarchyLevel.2/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+         </mdb:resourceScope>
+         <mdb:name>
+            <!-- Valid for conf.metadata-base-instance.scope-name -->
+            <gco:CharacterString>/*/gmd:hierarchyLevelName/gco:CharacterString</gco:CharacterString>
+         </mdb:name>
+      </mdb:MD_MetadataScope>
+   </mdb:metadataScope>
+   
+   <!-- No match for the context -->
+   <mdb:metadataScope>
+      <mdb:MD_MetadataScope>
+         <mdb:resourceScope>
+            <mcc:MD_ScopeCode codeList="codeListLocation#MD_ScopeCode" 
+               codeListValue="dataset">/*/gmd:hierarchyLevel.2/gmd:MD_ScopeCode</mcc:MD_ScopeCode>
+         </mdb:resourceScope>
+         <mdb:name>
+            <!-- Valid for conf.metadata-base-instance.scope-name -->
             <gco:CharacterString>/*/gmd:hierarchyLevelName/gco:CharacterString</gco:CharacterString>
          </mdb:name>
       </mdb:MD_MetadataScope>

--- a/ISO19115-3/mdb/1.0/2014-07-11/metadata-base.sch
+++ b/ISO19115-3/mdb/1.0/2014-07-11/metadata-base.sch
@@ -17,6 +17,13 @@
     <sch:diagnostic 
       id="conf.metadata-base-instance.root-element-failure-fr"
       xml:lang="fr">Modifier l'élément racine du document pour que ce soit un élément MD_Metadata.</sch:diagnostic>
+
+    <sch:diagnostic 
+      id="conf.metadata-base-instance.root-element-success-en"
+      xml:lang="en">Root element MD_Metadata found.</sch:diagnostic>
+    <sch:diagnostic 
+      id="conf.metadata-base-instance.root-element-success-fr"
+      xml:lang="fr">Élément racine MD_Metadata défini.</sch:diagnostic>
   </sch:diagnostics>
   
   <sch:pattern id="conf.metadata-base-instance.root-element">
@@ -29,9 +36,16 @@
       ISO19115-1 DOIT avoir un élément racine MD_Metadata (défini dans l'espace
       de nommage http://www.isotc211.org/2005/mdb/1.0).</sch:p>
     <sch:rule context="/">
-      <sch:assert test="(count(/mdb:MD_Metadata) = 1)"
+      <sch:let name="numberOfMD_MetadataElement" 
+               value="count(/mdb:MD_Metadata)"/>
+      
+      <sch:assert test="$numberOfMD_MetadataElement = 1"
       diagnostics="conf.metadata-base-instance.root-element-failure-en 
                    conf.metadata-base-instance.root-element-failure-fr"/>
+      
+      <sch:report test="$numberOfMD_MetadataElement = 1"
+        diagnostics="conf.metadata-base-instance.root-element-success-en 
+                     conf.metadata-base-instance.root-element-success-fr"/>
     </sch:rule>
   </sch:pattern>
   
@@ -42,11 +56,27 @@
     <sch:diagnostic 
       id="conf.metadata-base-instance.scope-name-failure-en" 
       xml:lang="en">Specify a name for the metadata scope 
-      (required if the scope code is not "dataset").</sch:diagnostic>
+      (required if the scope code is not "dataset", in that case
+      "<sch:value-of select="$scopeCode"/>").</sch:diagnostic>
     <sch:diagnostic 
       id="conf.metadata-base-instance.scope-name-failure-fr" 
       xml:lang="fr">Préciser la description du domaine d'application 
-      (car le document décrit une ressource qui n'est pas un "jeu de données").</sch:diagnostic>
+      (car le document décrit une ressource qui n'est pas un "jeu de données",
+      la ressource est de type "<sch:value-of select="$scopeCode"/>").</sch:diagnostic>
+    
+    
+    <sch:diagnostic 
+      id="conf.metadata-base-instance.scope-name-success-en" 
+      xml:lang="en">Scope name 
+      "<sch:value-of select="$scopeCodeName"/><sch:value-of select="$nilReason"/>"
+      is defined for resource with type "<sch:value-of select="$scopeCode"/>".
+    </sch:diagnostic>
+    <sch:diagnostic 
+      id="conf.metadata-base-instance.scope-name-success-fr" 
+      xml:lang="fr">La description du domaine d'application 
+      "<sch:value-of select="$scopeCodeName"/><sch:value-of select="$nilReason"/>"
+      est renseigné pour la ressource de type "<sch:value-of select="$scopeCode"/>".
+    </sch:diagnostic>
   </sch:diagnostics>
   
   <sch:pattern id="conf.metadata-base-instance.scope-name">
@@ -57,11 +87,30 @@
     <sch:p xml:lang="fr">Si un élément domaine d'application (MD_MetadataScope)
       est défini, sa description (name) DOIT avoir une valeur
       si se domaine n'est pas "jeu de données" (ie. "dataset").</sch:p>
-    <sch:rule context="//mdb:MD_MetadataScope/mdb:resourceScope/
-                          mcc:MD_ScopeCode[not(@codeListValue ='dataset')]">
-      <sch:assert test="(count(../../mdb:name)=1)"
+    
+    <sch:rule context="//mdb:MD_MetadataScope[not(mdb:resourceScope/
+                          mcc:MD_ScopeCode/@codeListValue ='dataset')]">
+      
+      <sch:let name="scopeCode" 
+        value="mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue"/>
+      
+      <sch:let name="scopeCodeName" 
+        value="normalize-space(mdb:name)"/>
+      <sch:let name="hasScopeCodeName" 
+        value="$scopeCodeName != ''"/>
+      
+      <sch:let name="nilReason" 
+        value="mdb:name/@gco:nilReason"/>
+      <sch:let name="hasNilReason" 
+        value="$nilReason != ''"/>
+      
+      <sch:assert test="$hasScopeCodeName or $hasNilReason"
         diagnostics="conf.metadata-base-instance.scope-name-failure-en
                      conf.metadata-base-instance.scope-name-failure-fr"/>
+      
+      <sch:report test="$hasScopeCodeName or $hasNilReason"
+        diagnostics="conf.metadata-base-instance.scope-name-success-en
+                     conf.metadata-base-instance.scope-name-success-fr"/>
     </sch:rule>
   </sch:pattern>
   


### PR DESCRIPTION
Regarding schematron, it could be relevant to introduce some changes if that sounds good to you.

The proposed changes:
- multilingual schematron (using xml:lang attribute and sch:diagnostics)
- report success (and not only failure) using sch:report
- report details of what is tested using variables (set by sch:let and displayed with sch:value-of)
- add XML file for unit testing the schematron rules

Also fix namespaces (pointing to the 2013-06-24 version).

Testing could be done in oxygenxml:

![image](https://cloud.githubusercontent.com/assets/1701393/5568325/f3ffbf8e-8f57-11e4-8080-cd077be11cba.png)

Therefore and before proceeding all schematron files, I would like to check with you:
- if you've any workflow to produce the schematron files (from the XSD tools used ?) or if we can update them directly ?
- if we have to follow any rules for reporting message (use same text as in the standards if available - it will not in the French version of the document) ? or do we have some freedom on this ?
- and if true, could we make the reporting message more "user-friendly" by reporting details (eg. https://github.com/fxprunayre/XML/compare/improvements/schematron/multilingual-using-diagnostics?expand=1#diff-4457ae9573f3864483f93533a8acca6cR70) ?
- for empty text, should we considered the nilReason attribute (eg. https://github.com/fxprunayre/XML/compare/improvements/schematron/multilingual-using-diagnostics?expand=1#diff-4457ae9573f3864483f93533a8acca6cR107) ?

Let me know what you think of thoses changes.
