### PR TITLE
From ISO19139 / Multilingual metadata record not converted properly

### DIFF
--- a/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -29,7 +29,7 @@
             The hasCharacterString variable was generalized to include situations where substitutions are
             being used gor gco:CharacterString, e.g. gmx:FileName.
         -->
-        <xsl:variable name="hasChildNode" select="count($nodeWithStringToWrite/*) = 1"/>
+        <xsl:variable name="hasChildNode" select="count($nodeWithStringToWrite/*) > 0"/>
         <xsl:if test="$nodeWithStringToWrite">
             <xsl:element name="{$elementName}">
                 <!-- Deal with attributes (may be in the old gco namespace -->
@@ -43,7 +43,7 @@
                             This could be any substitution for gco:CharacterString.
                             Get correct namespace and preserve name for substitutions
                         -->
-                    <xsl:for-each select="$nodeWithStringToWrite/*">
+                    <xsl:for-each select="$nodeWithStringToWrite/*[local-name() != 'PT_FreeText']">
                         <xsl:variable name="nameSpacePrefix">
                             <xsl:call-template name="getNamespacePrefix"/>
                         </xsl:variable>
@@ -53,7 +53,8 @@
                     </xsl:for-each>
                 </xsl:if>
                 <xsl:if test="$isMultilingual">
-                    <xsl:apply-templates select="$nodeWithStringToWrite/gmd:PT_FreeText"/>
+                    <xsl:apply-templates mode="from19139to19115-3"
+                                         select="$nodeWithStringToWrite/gmd:PT_FreeText"/>
                 </xsl:if>
             </xsl:element>
         </xsl:if>


### PR DESCRIPTION
```
<gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
                  <gco:CharacterString>Service de visualisation des limites administratives</gco:CharacterString>
                  <gmd:PT_FreeText>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#DUT">Dienst van de visualisatie van de administratieve eenheden</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#ENG">View service as regards the administrative units</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#GER">View service der Verwaltungseinheiten</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                  </gmd:PT_FreeText>
               </gmd:title>
```
is converted to
```
<cit:title>
Dienst van de visualisatie van de administratieve eenhedenView service as regards the administrative unitsView service der Verwaltungseinheiten
</cit:title>
```