### PR TITLE
Improve ISO19139 conversion

### DIFF
--- a/standards.iso.org/19115/resources/transforms/ISO19139/mapping/CI_Citation.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/mapping/CI_Citation.xsl
@@ -72,31 +72,27 @@
     <xsl:template match="gmd:CI_Citation/gmd:date" mode="from19139to19115-3">
         <cit:date>
             <xsl:apply-templates select="@*" mode="from19139to19115-3"/>
-            <xsl:choose>
-                <xsl:when test="normalize-space()=''"/>
-                <xsl:otherwise>
-                    <cit:CI_Date>
+            <xsl:if test="exists(descendant::gmd:date/*) or
+                          exists(descendant::gmd:dateType)">
+                <cit:CI_Date>
+                    <xsl:if test="
+                        exists(descendant::gmd:date/@gcoold:nilReason) or
+                        normalize-space(descendant::gmd:date/*/text()) != ''">
                         <cit:date>
-                            <xsl:choose>
-                                <xsl:when test="descendant::gmd:date/@gcoold:nilReason">
-                                    <!-- added this to get gmd:dates with gco:nilReason and dateTypes -->
-                                    <xsl:attribute name="gco:nilReason" select="descendant::gmd:date/@gcoold:nilReason"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:call-template name="writeDateTime"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
+                            <xsl:apply-templates mode="from19139to19115-3" 
+                                                 select="descendant::gmd:date/@gcoold:nilReason"/>
+                            <xsl:call-template name="writeDateTime"/>
                         </cit:date>
-                        <xsl:for-each select="descendant::gmd:dateType">
-                            <xsl:call-template name="writeCodelistElement">
-                                <xsl:with-param name="elementName" select="'cit:dateType'"/>
-                                <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
-                                <xsl:with-param name="codeListValue" select="gmd:CI_DateTypeCode/@codeListValue"/>
-                            </xsl:call-template>
-                        </xsl:for-each>
-                    </cit:CI_Date>
-                </xsl:otherwise>
-            </xsl:choose>
+                    </xsl:if>
+                    <xsl:for-each select="descendant::gmd:dateType">
+                        <xsl:call-template name="writeCodelistElement">
+                            <xsl:with-param name="elementName" select="'cit:dateType'"/>
+                            <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
+                            <xsl:with-param name="codeListValue" select="gmd:CI_DateTypeCode/@codeListValue"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
+                </cit:CI_Date>
+            </xsl:if>
         </cit:date>
     </xsl:template>
 

--- a/standards.iso.org/19115/resources/transforms/ISO19139/mapping/core.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/mapping/core.xsl
@@ -533,15 +533,16 @@
             </mri:name>
           </xsl:when>
         </xsl:choose>
+
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'mri:associationType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_AssociationTypeCode'"/>
-          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode"/>
+          <xsl:with-param name="codeListValue" select="gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode/@codeListValue"/>
         </xsl:call-template>
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'mri:initiativeType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_InitiativeTypeCode'"/>
-          <xsl:with-param name="codeListValue" select="./gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode"/>
+          <xsl:with-param name="codeListValue" select="gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode/@codeListValue"/>
         </xsl:call-template>
       </xsl:element>
     </mri:associatedResource>

--- a/standards.iso.org/19115/resources/transforms/ISO19139/toISO19139.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/toISO19139.xsl
@@ -691,8 +691,7 @@
   </xsl:template>
 
   <xsl:template match="gml32:*">
-    <xsl:element name="{local-name(.)}"
-                 namespace="http://www.opengis.net/gml">
+    <xsl:element name="gml:{local-name(.)}">
       <xsl:apply-templates select="@*"/>
       <xsl:apply-templates/>
     </xsl:element>

--- a/standards.iso.org/19115/resources/transforms/ISO19139/utility/dateTime.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/utility/dateTime.xsl
@@ -6,55 +6,28 @@
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 exclude-result-prefixes="#all">
 
-    <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet">
-        <xd:desc>
-            <xd:p><xd:b>Created on:</xd:b>December 5, 2014 </xd:p>
-            <xd:p>These templates transform ISO 19139 DateTime XML content into ISO 19115-3 DateTime.
-                They are designed to be imported as a template library</xd:p>
-            <xd:p>Version December 5, 2014</xd:p>
-            <xd:p><xd:b>Author:</xd:b>thabermann@hdfgroup.org</xd:p>
-        </xd:desc>
-    </xd:doc>
+  <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet">
+    <xd:desc>
+      <xd:p><xd:b>Created on:</xd:b>December 5, 2014
+      </xd:p>
+      <xd:p>These templates transform ISO 19139 DateTime XML content into ISO
+        19115-3 DateTime.
+        They are designed to be imported as a template library
+      </xd:p>
+      <xd:p>Version December 5, 2014</xd:p>
+      <xd:p><xd:b>Author:</xd:b>thabermann@hdfgroup.org
+      </xd:p>
+    </xd:desc>
+  </xd:doc>
 
-    <xsl:template name="writeDateTime">
-     <!--
-      have to account for gco:Date and gco:DateTime which are both valid descendants of gmd:date
-     -->
+  <xsl:template name="writeDateTime">
+    <xsl:for-each select="descendant::gcoold:*">
+      <xsl:element name="{concat('gco:',local-name(.))}">
         <xsl:apply-templates select="@*"
                              mode="from19139to19115-3"/>
-        <xsl:if test="descendant::gcoold:*">
-          <gco:DateTime>
-              <xsl:for-each select="descendant::gcoold:Date">
-                  <xsl:variable name="dateNodeString">
-                      <xsl:value-of select="xs:string(.)"/>
-                  </xsl:variable>
-                  <xsl:choose>
-                      <xsl:when test="string-length($dateNodeString)=4">
-                          <!-- Assume YYYY -->
-                          <xsl:value-of select="concat(substring($dateNodeString,1,4),'-01-01T00:00:00')"/>
-                      </xsl:when>
-                      <xsl:when test="string-length($dateNodeString)=6">
-                          <!-- Assume YYYYMM -->
-                          <xsl:value-of select="concat(substring($dateNodeString,1,4),'-',substring($dateNodeString,5,2),'-01T00:00:00')"/>
-                      </xsl:when>
-                      <xsl:when test="string-length($dateNodeString)=7">
-                          <!-- Assume YYYY-MM -->
-                          <xsl:value-of select="concat(substring($dateNodeString,1,4),'-',substring($dateNodeString,6,2),'-01T00:00:00')"/>
-                      </xsl:when>
-                      <xsl:when test="string-length($dateNodeString)=8">
-                          <!-- Assume YYYY-MM-DD -->
-                          <xsl:value-of select="concat(substring($dateNodeString,1,4),'-',substring($dateNodeString,5,2),'-',substring($dateNodeString,7,2),'T00:00:00')"/>
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:value-of select="concat($dateNodeString,'T00:00:00')"/>
-                      </xsl:otherwise>
-                  </xsl:choose>
-              </xsl:for-each>
-              <xsl:for-each select="descendant::gcoold:DateTime">
-                  <xsl:value-of select="."/>
-              </xsl:for-each>
-          </gco:DateTime>
-        </xsl:if>
-    </xsl:template>
-    
+        <xsl:value-of select="."/>
+      </xsl:element>
+    </xsl:for-each>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -27,7 +27,7 @@
         <xsl:variable name="isMultilingual" select="count($nodeWithStringToWrite/gmd:PT_FreeText) > 0"/>
         <!-- 
             The hasCharacterString variable was generalized to include situations where substitutions are
-            being used gor gco:CharacterString, e.g. gmx:FileName.
+            being used for gco:CharacterString, e.g. gmx:FileName.
         -->
         <xsl:variable name="hasChildNode" select="count($nodeWithStringToWrite/*) = 1"/>
         <xsl:if test="$nodeWithStringToWrite">

--- a/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/standards.iso.org/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -29,7 +29,7 @@
             The hasCharacterString variable was generalized to include situations where substitutions are
             being used for gco:CharacterString, e.g. gmx:FileName.
         -->
-        <xsl:variable name="hasChildNode" select="count($nodeWithStringToWrite/*) = 1"/>
+        <xsl:variable name="hasChildNode" select="count($nodeWithStringToWrite/*) > 0"/>
         <xsl:if test="$nodeWithStringToWrite">
             <xsl:element name="{$elementName}">
                 <!-- Deal with attributes (may be in the old gco namespace -->
@@ -43,7 +43,7 @@
                             This could be any substitution for gco:CharacterString.
                             Get correct namespace and preserve name for substitutions
                         -->
-                    <xsl:for-each select="$nodeWithStringToWrite/*">
+                    <xsl:for-each select="$nodeWithStringToWrite/*[local-name() != 'PT_FreeText']">
                         <xsl:variable name="nameSpacePrefix">
                             <xsl:call-template name="getNamespacePrefix"/>
                         </xsl:variable>
@@ -53,7 +53,9 @@
                     </xsl:for-each>
                 </xsl:if>
                 <xsl:if test="$isMultilingual">
-                    <xsl:apply-templates select="$nodeWithStringToWrite/gmd:PT_FreeText"/>
+                    <xsl:apply-templates
+                        mode="from19139to19115-3"
+                        select="$nodeWithStringToWrite/gmd:PT_FreeText"/>
                 </xsl:if>
             </xsl:element>
         </xsl:if>


### PR DESCRIPTION
- Fix codelist value for aggregationInfo, progressCode, spatialRepType
- Add the capability to dispatch links to resources define in portrayal, DQ to distributionInfo
- Fix missing dateStamp if no revision date defined. In that case, use the first date
- Fix bad position of spatialRepType
- Fix missing serviceType due to wrong namespace
- Fix missing date in CI_Citation
- Date can be gco:Date or gco:DateTime
- Date can have only gco:nilReason or only dateType

Contains also #158
