### PR TITLE
Add support to codelist value having multiple occurences

### DIFF
--- a/standards.iso.org/iso/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/standards.iso.org/iso/19115/resources/transforms/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -64,28 +64,31 @@
         <xsl:param name="codeListValue"/>
         <!-- The correct codeList Location goes here -->
         <xsl:variable name="codeListLocation" select="'codeListLocation'"/>
-        <xsl:if test="string-length($codeListValue) > 0">
-            <xsl:element name="{$elementName}">
-                <xsl:element name="{$codeListName}">
-                    <xsl:attribute name="codeList">
-                        <xsl:value-of select="$codeListLocation"/>
-                        <xsl:value-of select="'#'"/>
-                        <xsl:value-of select="substring-after($codeListName,':')"/>
-                    </xsl:attribute>
-                    <xsl:attribute name="codeListValue">
-                        <!-- the anyValidURI value is used for testing with paths -->
-                        <!--<xsl:value-of select="'anyValidURI'"/>-->
-                        <!-- commented out for testing -->
-                        <xsl:value-of select="$codeListValue"/>
-                    </xsl:attribute>
-                    <xsl:value-of select="$codeListValue"/>
-                </xsl:element>
-            </xsl:element>
-            <!--<xsl:if test="@*">
-                <xsl:element name="{$elementName}">
-                    <xsl:apply-templates select="@*"/>
-                </xsl:element>
-            </xsl:if>-->
-        </xsl:if>
+        
+        <xsl:for-each select="$codeListValue">
+          <xsl:if test="string-length(.) > 0">
+              <xsl:element name="{$elementName}">
+                  <xsl:element name="{$codeListName}">
+                      <xsl:attribute name="codeList">
+                          <xsl:value-of select="$codeListLocation"/>
+                          <xsl:value-of select="'#'"/>
+                          <xsl:value-of select="substring-after($codeListName,':')"/>
+                      </xsl:attribute>
+                      <xsl:attribute name="codeListValue">
+                          <!-- the anyValidURI value is used for testing with paths -->
+                          <!--<xsl:value-of select="'anyValidURI'"/>-->
+                          <!-- commented out for testing -->
+                          <xsl:value-of select="."/>
+                      </xsl:attribute>
+                      <xsl:value-of select="."/>
+                  </xsl:element>
+              </xsl:element>
+              <!--<xsl:if test="@*">
+                  <xsl:element name="{$elementName}">
+                      <xsl:apply-templates select="@*"/>
+                  </xsl:element>
+              </xsl:if>-->
+          </xsl:if>
+        </xsl:for-each>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
eg. spatialRepresentationType cardinality is 0..unbounded and if more than one instance is defined in the input record, the conversion fails with:
```
Description: XPTY0004: A sequence of more than one item is not allowed as the first argument of string-length() ("grid", "vector")
```

Fix by looping on all codeListValue attribute matches.


Reported here https://github.com/metadata101/iso19115-3/issues/27