### PR TITLE
update /resources/Codelist/cat/ to /resources/Codelists/cat/ in codel…

### DIFF
--- a/standards.iso.org/iso/19110/gfc/1.1/exampleInstance.xml
+++ b/standards.iso.org/iso/19110/gfc/1.1/exampleInstance.xml
@@ -43,7 +43,7 @@
 	<gfc:producer>
 		<cit:CI_Responsibility>
 		    <cit:role>
-		        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
+		        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
 		    </cit:role>
 		    <cit:party>
 		        <cit:CI_Organisation>
@@ -203,7 +203,7 @@
 		                                                <gco:Date>2010</gco:Date>
 		                                            </cit:date>
 		                                            <cit:dateType>
-		                                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+		                                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
 		                                            </cit:dateType>
 		                                        </cit:CI_Date>
 		                                    </cit:date>
@@ -226,7 +226,7 @@
 		                                        <gco:Date>1997-06-01</gco:Date>
 		                                    </cit:date>
 		                                    <cit:dateType>
-		                                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
+		                                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
 		                                    </cit:dateType>
 		                                </cit:CI_Date>
 		                            </cit:date>
@@ -371,7 +371,7 @@
 		                                        <gco:Date>1997-06-01</gco:Date>
 		                                    </cit:date>
 		                                    <cit:dateType>
-		                                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
+		                                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
 		                                    </cit:dateType>
 		                                </cit:CI_Date>
 		                            </cit:date>

--- a/standards.iso.org/iso/19115/-3/mac/2.0/mac.xml
+++ b/standards.iso.org/iso/19115/-3/mac/2.0/mac.xml
@@ -8,7 +8,7 @@
     <mac:scope>
         <mcc:MD_Scope>
             <mcc:level>
-                <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#" codeListValue="mcc:MD_ScopeCode">mcc:MD_ScopeCode</mcc:MD_ScopeCode>
+                <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#" codeListValue="mcc:MD_ScopeCode">mcc:MD_ScopeCode</mcc:MD_ScopeCode>
             </mcc:level>
             <mcc:extent>
                 <gex:EX_Extent>

--- a/standards.iso.org/iso/19115/-3/mdb/1.0/AppendixD.1MinimalExample.xml
+++ b/standards.iso.org/iso/19115/-3/mdb/1.0/AppendixD.1MinimalExample.xml
@@ -14,7 +14,7 @@
     <mdb:contact>
         <cit:CI_Responsibility>
             <cit:role>
-                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
+                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
             </cit:role>
             <cit:party>
                 <cit:CI_Organisation>
@@ -32,7 +32,7 @@
                 <gco:DateTime>2004-03-12T12:00:00</gco:DateTime>
             </cit:date>
             <cit:dateType>
-                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#creation" codeListValue="Creation"/>
+                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#creation" codeListValue="Creation"/>
             </cit:dateType>
         </cit:CI_Date>
     </mdb:dateInfo>
@@ -51,7 +51,7 @@
                                 <gco:DateTime>1993-01-01T12:00:00</gco:DateTime>
                             </cit:date>
                             <cit:dateType>
-                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
                             </cit:dateType>
                         </cit:CI_Date>
                     </cit:date>    

--- a/standards.iso.org/iso/19115/-3/mds/1.0/AppendixD.2VectorSmartMapExample.xml
+++ b/standards.iso.org/iso/19115/-3/mds/1.0/AppendixD.2VectorSmartMapExample.xml
@@ -42,7 +42,7 @@
     <mdb:contact>
         <cit:CI_Responsibility>
             <cit:role>
-                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="publisher"/>
+                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="publisher"/>
             </cit:role>
             <cit:party>
                 <cit:CI_Organisation>
@@ -67,7 +67,7 @@
                 <gco:DateTime>2004-03-14T12:00:00</gco:DateTime>
             </cit:date>
             <cit:dateType>
-                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
+                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
             </cit:dateType>
         </cit:CI_Date>
     </mdb:dateInfo>
@@ -116,12 +116,12 @@
                                 <gco:DateTime>2000-09-03T12:00:00</gco:DateTime>
                             </cit:date>
                             <cit:dateType>
-                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
+                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="publication"/>
                             </cit:dateType>
                         </cit:CI_Date>
                     </cit:date>
                     <cit:presentationForm>
-                        <cit:CI_PresentationFormCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital"/>
+                        <cit:CI_PresentationFormCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_PresentationFormCode" codeListValue="mapDigital"/>
                     </cit:presentationForm>
                 </cit:CI_Citation>
             </mri:citation>
@@ -130,12 +130,12 @@
                     applications</gco:CharacterString>
             </mri:abstract>
             <mri:status>
-                <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#MD_ProgressCode" codeListValue="completed"/>
+                <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#MD_ProgressCode" codeListValue="completed"/>
             </mri:status>
             <mri:pointOfContact>
                 <cit:CI_Responsibility id="ID00001">
                     <cit:role>
-                        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="originator"/>
+                        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="originator"/>
                     </cit:role>
                     <cit:party>
                         <cit:CI_Organisation>
@@ -181,7 +181,7 @@
                                                 <gco:CharacterString>http</gco:CharacterString>
                                             </cit:protocol>
                                             <cit:function>
-                                                <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                                                <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
                                             </cit:function>
                                         </cit:CI_OnlineResource>
                                     </cit:onlineResource>
@@ -200,7 +200,7 @@
             </mri:pointOfContact>
             <mri:spatialRepresentationType>
 
-                <mcc:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector"/>
+                <mcc:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector"/>
             </mri:spatialRepresentationType>
             <mri:spatialResolution>
                 <mri:MD_Resolution>
@@ -366,7 +366,7 @@
                     <mrd:distributorContact>
                         <cit:CI_Responsibility>
                             <cit:role>
-                                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="distributor"/>
+                                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="distributor"/>
                             </cit:role>
                             <cit:party>
                                 <cit:CI_Individual>
@@ -389,7 +389,7 @@
                                                   <gco:CharacterString>555-555-5555</gco:CharacterString>
                                                   </cit:number>
                                                   <cit:numberType>
-                                                  <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_TelephoneTypeCode" codeListValue="office"/>
+                                                  <cit:CI_TelephoneTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_TelephoneTypeCode" codeListValue="office"/>
                                                   </cit:numberType>
                                                 </cit:CI_Telephone>
                                             </cit:phone>
@@ -425,7 +425,7 @@
                                         <gco:CharacterString>http://geoengine.nga.mil/ftpdir/archive/vpf_data/v0noa.tar.gz</gco:CharacterString>
                                     </cit:linkage>
                                     <cit:function>
-                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
                                     </cit:function>
                                 </cit:CI_OnlineResource>
                             </mrd:onLine>
@@ -435,7 +435,7 @@
                                         <gco:CharacterString>http://geoengine.nga.mil/ftpdir/archive/vpf_data/v0sas.tar.gz</gco:CharacterString>
                                     </cit:linkage>
                                     <cit:function>
-                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
                                     </cit:function>
                                 </cit:CI_OnlineResource>
                             </mrd:onLine>
@@ -445,7 +445,7 @@
                                         <gco:CharacterString>http://geoengine.nga.mil/ftpdir/archive/vpf_data/v0soa.tar.gz</gco:CharacterString>
                                     </cit:linkage>
                                     <cit:function>
-                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="download"/>
                                     </cit:function>
                                 </cit:CI_OnlineResource>
                             </mrd:onLine>
@@ -459,7 +459,7 @@
                     <mrd:distributorContact>
                         <cit:CI_Responsibility>
                             <cit:role>
-                                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_RoleCode" codeListValue="distributor"/>
+                                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_RoleCode" codeListValue="distributor"/>
                             </cit:role>
                             <cit:party>
                                 <cit:CI_Individual>
@@ -497,7 +497,7 @@
                                                   <gco:CharacterString>http://www.dscr.dla.mil/pc9</gco:CharacterString>
                                                   </cit:linkage>
                                                   <cit:function>
-                                                  <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="order"/>
+                                                  <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_OnLineFunctionCode" codeListValue="order"/>
                                                   </cit:function>
                                                 </cit:CI_OnlineResource>
                                             </cit:onlineResource>
@@ -543,7 +543,7 @@
                                         <gco:Integer>4</gco:Integer>
                                     </mrd:volumes>
                                     <mrd:mediumFormat>
-                                        <mrd:MD_MediumFormatCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#MD_MediumFormatCode" codeListValue="iso9660"/>
+                                        <mrd:MD_MediumFormatCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#MD_MediumFormatCode" codeListValue="iso9660"/>
                                     </mrd:mediumFormat>
                                 </mrd:MD_Medium>
                             </mrd:offLine>
@@ -559,7 +559,7 @@
             <mdq:scope>
                 <mcc:MD_Scope>
                     <mcc:level>
-                        <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#MD_ScopeCode" codeListValue="dataset"/>
+                        <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#MD_ScopeCode" codeListValue="dataset"/>
                     </mcc:level>
                 </mcc:MD_Scope>
             </mdq:scope>
@@ -586,7 +586,7 @@
                                                 <gco:DateTime>1995-02-09T00:00:00Z</gco:DateTime>
                                             </cit:date>
                                             <cit:dateType>
-                                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
+                                                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#CI_DateTypeCode" codeListValue="creation"/>
                                             </cit:dateType>
                                         </cit:CI_Date>
                                     </cit:date>
@@ -619,7 +619,7 @@
     <mdb:metadataConstraints>
         <mco:MD_SecurityConstraints>
             <mco:classification>
-                <mco:MD_ClassificationCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codeList.xml#MD_ClassificationCode" codeListValue="unclassified"/>
+                <mco:MD_ClassificationCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codeList.xml#MD_ClassificationCode" codeListValue="unclassified"/>
             </mco:classification>
             <mco:handlingDescription>
                 <gco:CharacterString>RELEASABILITY - unrestricted</gco:CharacterString>

--- a/standards.iso.org/iso/19115/-3/mds/2.0/mds.xml
+++ b/standards.iso.org/iso/19115/-3/mds/2.0/mds.xml
@@ -169,7 +169,7 @@
          <mac:scope>
             <mcc:MD_Scope>
                <mcc:level>
-                  <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#" codeListValue="mcc:MD_ScopeCode">mcc:MD_ScopeCode</mcc:MD_ScopeCode>
+                  <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#" codeListValue="mcc:MD_ScopeCode">mcc:MD_ScopeCode</mcc:MD_ScopeCode>
                </mcc:level>
                <mcc:extent>
                   <gex:EX_Extent>

--- a/standards.iso.org/iso/19115/-3/mrc/2.0/mrc.xml
+++ b/standards.iso.org/iso/19115/-3/mrc/2.0/mrc.xml
@@ -20,7 +20,7 @@
          <mrc:attributeGroup>
             <mrc:MD_AttributeGroup id="MD_AttributeGroupTarget">
                <mrc:contentType>
-                  <mrc:MD_CoverageContentTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CoverageContentTypeCode" codeListValue="physicalMeasurement">mrc:contentType/mrc:MD_CoverageContentTypeCode</mrc:MD_CoverageContentTypeCode>
+                  <mrc:MD_CoverageContentTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CoverageContentTypeCode" codeListValue="physicalMeasurement">mrc:contentType/mrc:MD_CoverageContentTypeCode</mrc:MD_CoverageContentTypeCode>
                </mrc:contentType>
                <mrc:attribute>
                   <mrc:MD_SampleDimension>
@@ -135,7 +135,7 @@
          <mrc:attributeGroup>
             <mrc:MD_AttributeGroup>
                <mrc:contentType>
-                  <mrc:MD_CoverageContentTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CoverageContentTypeCode" codeListValue="referenceInformation">mrc:contentType/mrc:MD_CoverageContentTypeCode</mrc:MD_CoverageContentTypeCode>
+                  <mrc:MD_CoverageContentTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CoverageContentTypeCode" codeListValue="referenceInformation">mrc:contentType/mrc:MD_CoverageContentTypeCode</mrc:MD_CoverageContentTypeCode>
                </mrc:contentType>
                <mrc:attribute>
                   <mrc:MD_SampleDimension>

--- a/standards.iso.org/iso/19115/-3/mrd/1.0/codelists.xml
+++ b/standards.iso.org/iso/19115/-3/mrd/1.0/codelists.xml
@@ -24,10 +24,10 @@
    <cat:locale>
       <lan:PT_Locale>
          <lan:language>
-            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
          </lan:language>
          <lan:characterEncoding>
-            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CharacterSetCode"
+            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
                codeListValue="UTF-8">UTF-8</lan:MD_CharacterSetCode>
          </lan:characterEncoding>
       </lan:PT_Locale>

--- a/standards.iso.org/iso/19115/-3/mri/1.0/codelists.xml
+++ b/standards.iso.org/iso/19115/-3/mri/1.0/codelists.xml
@@ -24,10 +24,10 @@
    <cat:locale>
       <lan:PT_Locale>
          <lan:language>
-            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
          </lan:language>
          <lan:characterEncoding>
-            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CharacterSetCode"
+            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
                codeListValue="UTF-8">UTF-8</lan:MD_CharacterSetCode>
          </lan:characterEncoding>
       </lan:PT_Locale>

--- a/standards.iso.org/iso/19115/-3/mrs/1.0/codelists.xml
+++ b/standards.iso.org/iso/19115/-3/mrs/1.0/codelists.xml
@@ -20,10 +20,10 @@
    <cat:locale>
       <lan:PT_Locale>
          <lan:language>
-            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
          </lan:language>
          <lan:characterEncoding>
-            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CharacterSetCode" codeListValue="UTF-8">UTF-8</lan:MD_CharacterSetCode>
+            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="UTF-8">UTF-8</lan:MD_CharacterSetCode>
          </lan:characterEncoding>
       </lan:PT_Locale>
    </cat:locale>

--- a/standards.iso.org/iso/19115/-3/msr/2.0/msr.xml
+++ b/standards.iso.org/iso/19115/-3/msr/2.0/msr.xml
@@ -26,7 +26,7 @@
     <msr:axisDimensionProperties>
         <msr:MD_Dimension>
             <msr:dimensionName>
-                <msr:MD_DimensionNameTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_DimensionNameTypeCode" codeListValue="row">msr:dimensionName/msr:MD_DimensionNameTypeCode</msr:MD_DimensionNameTypeCode>
+                <msr:MD_DimensionNameTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_DimensionNameTypeCode" codeListValue="row">msr:dimensionName/msr:MD_DimensionNameTypeCode</msr:MD_DimensionNameTypeCode>
             </msr:dimensionName>
             <msr:dimensionSize>
                 <gco:Integer>555</gco:Integer>
@@ -39,7 +39,7 @@
     <msr:axisDimensionProperties>
         <msr:MD_Dimension>
             <msr:dimensionName>
-                <msr:MD_DimensionNameTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_DimensionNameTypeCode" codeListValue="column">msr:dimensionName/msr:MD_DimensionNameTypeCode</msr:MD_DimensionNameTypeCode>
+                <msr:MD_DimensionNameTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_DimensionNameTypeCode" codeListValue="column">msr:dimensionName/msr:MD_DimensionNameTypeCode</msr:MD_DimensionNameTypeCode>
             </msr:dimensionName>
             <msr:dimensionSize>
                 <gco:Integer>556</gco:Integer>
@@ -50,7 +50,7 @@
         </msr:MD_Dimension>
     </msr:axisDimensionProperties>
     <msr:cellGeometry>
-        <msr:MD_CellGeometryCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CellGeometryCode" codeListValue="area">msr:cellGeometry/msr:MD_CellGeometryCode</msr:MD_CellGeometryCode>
+        <msr:MD_CellGeometryCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CellGeometryCode" codeListValue="area">msr:cellGeometry/msr:MD_CellGeometryCode</msr:MD_CellGeometryCode>
     </msr:cellGeometry>
     <msr:transformationParameterAvailability gco:nilReason="unknown"/>
     <msr:checkPointAvailability gco:nilReason="unknown"/>

--- a/standards.iso.org/iso/19115/-3/srv/2.0/codelists.xml
+++ b/standards.iso.org/iso/19115/-3/srv/2.0/codelists.xml
@@ -24,10 +24,10 @@
    <cat:locale>
       <lan:PT_Locale>
          <lan:language>
-            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+            <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
          </lan:language>
          <lan:characterEncoding>
-            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/cat/codelists.xml#MD_CharacterSetCode"
+            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
                codeListValue="UTF-8">UTF-8</lan:MD_CharacterSetCode>
          </lan:characterEncoding>
       </lan:PT_Locale>


### PR DESCRIPTION
fix url for codelists at https://standards.iso.org/iso/19115/resources/Codelists, change /Codelist/ to /Codelists/ .  Changed in 41 places, all in .xml example files.

addresses issue #201