### PR TITLE
Creation of 2.0 namespace schematron

### DIFF
--- a/standards.iso.org/iso/19115/-3/cit/2.0/cit.sch
+++ b/standards.iso.org/iso/19115/-3/cit/2.0/cit.sch
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="cit" uri="http://standards.iso.org/iso/19115/-3/cit/2.0"/>
+  <sch:ns prefix="mri" uri="http://standards.iso.org/iso/19115/-3/mri/1.0"/>
+  <sch:ns prefix="srv" uri="http://standards.iso.org/iso/19115/-3/srv/2.0"/>
+  <sch:ns prefix="mdb" uri="http://standards.iso.org/iso/19115/-3/mdb/2.0"/>
+  <sch:ns prefix="mcc" uri="http://standards.iso.org/iso/19115/-3/mcc/1.0"/>
+  <sch:ns prefix="lan" uri="http://standards.iso.org/iso/19115/-3/lan/1.0"/>
+  <sch:ns prefix="gco" uri="http://standards.iso.org/iso/19115/-3/gco/1.0"/>
+  <!--
+    ISO 19115-3 base requirements for metadata instance documents
+    
+    See ISO19115-1:2014(E) page 25, Figure 20 Citation and responsible party information classes
+  -->
+  
+  <!-- 
+    Rule: CI_Individual
+    Ref: {count(name + positionName) > 0}
+    -->
+  <sch:diagnostics>
+    <sch:diagnostic id="rule.cit.individualnameandposition-failure-en"
+      xml:lang="en">The individual does not have a name or a position.</sch:diagnostic>
+    <sch:diagnostic id="rule.cit.individualnameandposition-failure-fr"
+      xml:lang="fr">Une personne n'a pas de nom ou de fonction.</sch:diagnostic>
+    
+    <sch:diagnostic id="rule.cit.individualnameandposition-success-en"
+      xml:lang="en">Individual name is  
+      "<sch:value-of select="normalize-space($name)"/>"
+      and position
+      "<sch:value-of select="normalize-space($position)"/>"
+      .</sch:diagnostic>
+    <sch:diagnostic id="rule.cit.individualnameandposition-success-fr"
+      xml:lang="fr">Le nom de la personne est  
+      "<sch:value-of select="normalize-space($name)"/>"
+      ,sa fonction 
+      "<sch:value-of select="normalize-space($position)"/>"
+      .</sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.cit.individualnameandposition">
+    <sch:title xml:lang="en">Individual MUST have a name or a position</sch:title>
+    <sch:title xml:lang="fr">Une personne DOIT avoir un nom ou une fonction</sch:title>
+    
+    <sch:rule context="//cit:CI_Individual">
+      
+      <sch:let name="name" value="cit:name"/>
+      <sch:let name="position" value="cit:positionName"/>
+      <sch:let name="hasName" 
+               value="normalize-space($name) != ''"/>
+      <sch:let name="hasPosition" 
+        value="normalize-space($position) != ''"/>
+      
+      <sch:assert test="$hasName or $hasPosition"
+        diagnostics="rule.cit.individualnameandposition-failure-en 
+                     rule.cit.individualnameandposition-failure-fr"/>
+      
+      <sch:report test="$hasName or $hasPosition"
+        diagnostics="rule.cit.individualnameandposition-success-en 
+                     rule.cit.individualnameandposition-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+  
+  
+  
+  
+  <!-- 
+    Rule: CI_Organisation
+    Ref: {count(name + logo) > 0}
+  -->
+  <sch:diagnostics>
+    <sch:diagnostic id="rule.cit.organisationnameandlogo-failure-en"
+      xml:lang="en">The organisation does not have a name or a logo.</sch:diagnostic>
+    <sch:diagnostic id="rule.cit.organisationnameandlogo-failure-fr"
+      xml:lang="fr">Une organisation n'a pas de nom ou de logo.</sch:diagnostic>
+    
+    <sch:diagnostic id="rule.cit.organisationnameandlogo-success-en"
+      xml:lang="en">Organisation name is  
+      "<sch:value-of select="normalize-space($name)"/>"
+      and logo filename is 
+      "<sch:value-of select="normalize-space($logo)"/>"
+      .</sch:diagnostic>
+    <sch:diagnostic id="rule.cit.organisationnameandlogo-success-fr"
+      xml:lang="fr">Le nom de l'organisation est  
+      "<sch:value-of select="normalize-space($name)"/>"
+      , son logo
+      "<sch:value-of select="normalize-space($logo)"/>"
+      .</sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.cit.organisationnameandlogo">
+    <sch:title xml:lang="en">Organisation MUST have a name or a logo</sch:title>
+    <sch:title xml:lang="fr">Une organisation DOIT avoir un nom ou un logo</sch:title>
+    
+    <sch:rule context="//cit:CI_Organisation">
+      
+      <sch:let name="name" value="cit:name"/>
+      <sch:let name="logo" value="cit:logo/mcc:MD_BrowseGraphic/mcc:fileName"/>
+      <sch:let name="hasName" 
+        value="normalize-space($name) != ''"/>
+      <sch:let name="hasLogo" 
+        value="normalize-space($logo) != ''"/>
+      
+      <sch:assert test="$hasName or $hasLogo"
+        diagnostics="rule.cit.organisationnameandlogo-failure-en 
+                     rule.cit.organisationnameandlogo-failure-fr"/>
+      
+      <sch:report test="$hasName or $hasLogo"
+        diagnostics="rule.cit.organisationnameandlogo-success-en 
+                     rule.cit.organisationnameandlogo-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+  
+</sch:schema>

--- a/standards.iso.org/iso/19115/-3/mdb/2.0/mdb.sch
+++ b/standards.iso.org/iso/19115/-3/mdb/2.0/mdb.sch
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="cit" uri="http://standards.iso.org/iso/19115/-3/cit/2.0"/>
+  <sch:ns prefix="mri" uri="http://standards.iso.org/iso/19115/-3/mri/1.0"/>
+  <sch:ns prefix="mdb" uri="http://standards.iso.org/iso/19115/-3/mdb/2.0"/>
+  <sch:ns prefix="mcc" uri="http://standards.iso.org/iso/19115/-3/mcc/1.0"/>
+  <sch:ns prefix="lan" uri="http://standards.iso.org/iso/19115/-3/lan/1.0"/>
+  <sch:ns prefix="gco" uri="http://standards.iso.org/iso/19115/-3/gco/1.0"/>
+  <!--
+    ISO 19115-3 base requirements for metadata instance documents
+    
+    See ISO19115-1:2014(E) page 10, Figure 5
+  -->
+  
+  <!-- 
+    Rule: Check root element. 
+    Ref: N/A
+  -->
+  <sch:diagnostics>
+    <sch:diagnostic 
+      id="rule.mdb.root-element-failure-en"
+      xml:lang="en">The root element must be MD_Metadata.</sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.root-element-failure-fr"
+      xml:lang="fr">Modifier l'élément racine du document pour que ce 
+      soit un élément MD_Metadata.</sch:diagnostic>
+
+    <sch:diagnostic 
+      id="rule.mdb.root-element-success-en"
+      xml:lang="en">Root element MD_Metadata found.</sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.root-element-success-fr"
+      xml:lang="fr">Élément racine MD_Metadata défini.</sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.mdb.root-element">
+    <sch:title xml:lang="en">Metadata document root element</sch:title>
+    <sch:title xml:lang="fr">Élément racine du document</sch:title>
+    
+    <sch:p xml:lang="en">A metadata instance document conforming to 
+      this specification SHALL have a root MD_Metadata element 
+      defined in the http://standards.iso.org/iso/19115/-3/mdb/1.0 namespace.</sch:p>
+    <sch:p xml:lang="fr">Une fiche de métadonnées conforme au standard
+      ISO19115-1 DOIT avoir un élément racine MD_Metadata (défini dans l'espace
+      de nommage http://standards.iso.org/iso/19115/-3/mdb/1.0).</sch:p>
+    <sch:rule context="/">
+      <sch:let name="hasOneMD_MetadataElement" 
+               value="count(/mdb:MD_Metadata) = 1"/>
+      
+      <sch:assert test="$hasOneMD_MetadataElement"
+      diagnostics="rule.mdb.root-element-failure-en 
+                   rule.mdb.root-element-failure-fr"/>
+      
+      <sch:report test="$hasOneMD_MetadataElement"
+        diagnostics="rule.mdb.root-element-success-en 
+                     rule.mdb.root-element-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+  
+  
+  
+  
+  <!-- 
+    Rule:  
+    Ref: {defaultLocale documented if not defined by the encoding}
+    This can't be validated because the encoding is part of the default locale ? TODO-QUESTION
+    
+    Ref: {defaultLocale.PT_Locale.characterEncoding default value is UTF-8}
+    Check that encoding is not empty.
+  -->
+  
+  <sch:diagnostics>
+    <sch:diagnostic 
+      id="rule.mdb.defaultlocale-failure-en" 
+      xml:lang="en">The default locale character encoding is "UTF-8". Current value is
+      "<sch:value-of select="$encoding"/>".</sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.defaultlocale-failure-fr" 
+      xml:lang="fr">L'encodage ne doit pas être vide. La valeur par défaut est 
+      "UTF-8". La valeur actuelle est "<sch:value-of select="$encoding"/>".</sch:diagnostic>
+    
+    
+    <sch:diagnostic 
+      id="rule.mdb.defaultlocale-success-en" 
+      xml:lang="en">The characeter encoding is "<sch:value-of select="$encoding"/>.
+    </sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.defaultlocale-success-fr" 
+      xml:lang="fr">L'encodage est "<sch:value-of select="$encoding"/>.
+    </sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.mdb.defaultlocale">
+    <sch:title xml:lang="en">Default locale</sch:title>
+    <sch:title xml:lang="fr">Langue du document</sch:title>
+    
+    <sch:p xml:lang="en">The default locale MUST be documented if
+      not defined by the encoding. The default value for the character
+      encoding is "UTF-8".</sch:p>
+    <sch:p xml:lang="fr">La langue doit être documentée
+      si non définie par l'encodage. L'encodage par défaut doit être "UTF-8".</sch:p>
+    
+    <sch:rule context="/mdb:MD_Metadata/mdb:defaultLocale|
+                       /mdb:MD_Metadata/mdb:identificationInfo/*/mri:defaultLocale">
+      
+      <sch:let name="encoding" 
+        value="string(lan:PT_Locale/lan:characterEncoding/
+                  lan:MD_CharacterSetCode/@codeListValue)"/>
+      
+      <sch:let name="hasEncoding" 
+        value="normalize-space($encoding) != ''"/>
+      
+      
+      <sch:assert test="$hasEncoding"
+        diagnostics="rule.mdb.defaultlocale-failure-en
+                     rule.mdb.defaultlocale-failure-fr"/>
+      
+      <sch:report test="$hasEncoding"
+        diagnostics="rule.mdb.defaultlocale-success-en
+                     rule.mdb.defaultlocale-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+ 
+ 
+  <!-- 
+    Rule: 
+    Ref: {count(MD_Metadata.parentMetadata) > 0 when there is an higher 
+    level object}
+    Comment: Can't be validated using schematron AFA the existence
+    of an higher level object can't be checked. TODO-QUESTION
+  -->
+  
+  
+  <!--
+    Rule:  
+    Ref: {count(MD_Metadata.metadataScope) > 0 if 
+    MD_Metadata.metadataScope.MD_MetadataScope.resourceScope
+    not equal to "dataset"}
+    
+    Ref: {name is mandatory if resourceScope not equal to "dataset"}
+  -->
+  <sch:diagnostics>
+    <sch:diagnostic 
+      id="rule.mdb.scope-name-failure-en" 
+      xml:lang="en">Specify a name for the metadata scope 
+      (required if the scope code is not "dataset", in that case
+      "<sch:value-of select="$scopeCode"/>").</sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.scope-name-failure-fr" 
+      xml:lang="fr">Préciser la description du domaine d'application 
+      (car le document décrit une ressource qui n'est pas un "jeu de données",
+      la ressource est de type "<sch:value-of select="$scopeCode"/>").</sch:diagnostic>
+    
+    
+    <sch:diagnostic 
+      id="rule.mdb.scope-name-success-en" 
+      xml:lang="en">Scope name 
+      "<sch:value-of select="$scopeCodeName"/><sch:value-of select="$nilReason"/>"
+      is defined for resource with type "<sch:value-of select="$scopeCode"/>".
+    </sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.scope-name-success-fr" 
+      xml:lang="fr">La description du domaine d'application 
+      "<sch:value-of select="$scopeCodeName"/><sch:value-of select="$nilReason"/>"
+      est renseignée pour la ressource de type "<sch:value-of select="$scopeCode"/>".
+    </sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.mdb.scope-name">
+    <sch:title xml:lang="en">Metadata scope Name</sch:title>
+    <sch:title xml:lang="fr">Description du domaine d'application</sch:title>
+    
+    <sch:p xml:lang="en">If a MD_MetadataScope element is present, 
+      the name property MUST have a value if resourceScope is not equal to "dataset"</sch:p>
+    <sch:p xml:lang="fr">Si un élément domaine d'application (MD_MetadataScope)
+      est défini, sa description (name) DOIT avoir une valeur
+      si ce domaine n'est pas "jeu de données" (ie. "dataset").</sch:p>
+    
+    <sch:rule context="/mdb:MD_Metadata/mdb:metadataScope/
+                          mdb:MD_MetadataScope[not(mdb:resourceScope/
+                            mcc:MD_ScopeCode/@codeListValue = 'dataset')]">
+      
+      <sch:let name="scopeCode" 
+        value="mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue"/>
+      
+      <sch:let name="scopeCodeName" 
+        value="normalize-space(mdb:name)"/>
+      <sch:let name="hasScopeCodeName" 
+        value="normalize-space($scopeCodeName) != ''"/>
+      
+      <sch:let name="nilReason" 
+        value="mdb:name/@gco:nilReason"/>
+      <sch:let name="hasNilReason" 
+        value="$nilReason != ''"/>
+      
+      <sch:assert test="$hasScopeCodeName or $hasNilReason"
+        diagnostics="rule.mdb.scope-name-failure-en
+                     rule.mdb.scope-name-failure-fr"/>
+      
+      <sch:report test="$hasScopeCodeName or $hasNilReason"
+        diagnostics="rule.mdb.scope-name-success-en
+                     rule.mdb.scope-name-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+  
+  
+  <!-- 
+    Rule: At least one creation date
+    Ref: {count(MD _Metadata.dateInfo.CI_Date.dateType.CI_DateTypeCode= "creation") > 0}
+  -->
+  <sch:diagnostics>
+    <sch:diagnostic 
+      id="rule.mdb.create-date-failure-en"
+      xml:lang="en">Specify a creation date for the metadata record 
+      in the metadata section.</sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.create-date-failure-fr"
+      xml:lang="fr">Définir une date de création pour le document
+      dans la section sur les métadonnées.</sch:diagnostic>
+    
+    <sch:diagnostic 
+      id="rule.mdb.create-date-success-en" 
+      xml:lang="en">
+      Metadata creation date: <sch:value-of select="$creationDates"/>.
+    </sch:diagnostic>
+    <sch:diagnostic 
+      id="rule.mdb.create-date-success-fr" 
+      xml:lang="fr">
+      Date de création du document : <sch:value-of select="$creationDates"/>.
+    </sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.mdb.create-date">
+    <sch:title xml:lang="en">Metadata create date</sch:title>
+    <sch:title xml:lang="fr">Date de création du document</sch:title>
+    
+    <sch:p xml:lang="en">A dateInfo property value with data type = "creation" 
+      MUST be present in every MD_Metadata instance.</sch:p>
+    <sch:p xml:lang="fr">Tout document DOIT avoir une date de création 
+      définie (en utilisant un élément dateInfo avec un type de date "creation").</sch:p>
+    
+    <sch:rule context="mdb:MD_Metadata">
+      <sch:let name="creationDates"
+        value="./mdb:dateInfo/cit:CI_Date[
+                    normalize-space(cit:date/gco:DateTime) != '' and 
+                    cit:dateType/cit:CI_DateTypeCode/@codeListValue = 'creation']/
+                  cit:date/gco:DateTime"/>
+      
+      <!-- Check at least one non empty creation date element is defined. -->
+      <sch:let name="hasAtLeastOneCreationDate"
+        value="count(./mdb:dateInfo/cit:CI_Date[
+                    normalize-space(cit:date/gco:DateTime) != '' and 
+                    cit:dateType/cit:CI_DateTypeCode/@codeListValue = 'creation']
+                    ) &gt; 0"/>
+      
+      <sch:assert test="$hasAtLeastOneCreationDate"
+        diagnostics="rule.mdb.create-date-failure-en
+                     rule.mdb.create-date-failure-fr"/>
+      <sch:report test="$hasAtLeastOneCreationDate"
+        diagnostics="rule.mdb.create-date-success-en
+                     rule.mdb.create-date-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>

--- a/standards.iso.org/iso/19115/-3/mrc/2.0/mrc.sch
+++ b/standards.iso.org/iso/19115/-3/mrc/2.0/mrc.sch
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  <sch:ns prefix="mrc" uri="http://standards.iso.org/iso/19115/-3/mrc/2.0"/>
+  <!--
+    ISO 19115-3 base requirements for metadata instance documents
+    
+    See ISO19115-1:2014(E) page 18, Figure 13 Content information classes
+  -->
+  
+  
+  
+  <!-- 
+    Rule: MD_FeatureCatalogueDescription
+    Ref: {if FeatureCatalogue not included with resource and
+          MD_FeatureCatalogue not provided then
+            featureCatalogueCitation > 0}
+    Comment: No test because feature catalogue with resource can't be asserted (TODO-QUESTION)
+    -->
+  
+  
+  
+  <!-- 
+    Rule: MD_SampleDimension
+    Ref: {if count(maxValue + minValue + meanValue) > 0 then units is
+          mandatory}
+    -->
+  <sch:diagnostics>
+    <sch:diagnostic id="rule.mrc.sampledimension-failure-en"
+      xml:lang="en">The sample dimension defines a max, min or mean value without unit.</sch:diagnostic>
+    <sch:diagnostic id="rule.mrc.sampledimension-failure-fr"
+      xml:lang="fr">La dimension de l'échantillon définit une valeur max, min ou moyenne sans unité.</sch:diagnostic>
+    
+    <sch:diagnostic id="rule.mrc.sampledimension-max-success-en"
+      xml:lang="en">
+      The sample dimension unit is 
+      "<sch:value-of select="normalize-space($units)"/>".
+    </sch:diagnostic>
+    <sch:diagnostic id="rule.mrc.sampledimension-max-success-fr"
+      xml:lang="fr">
+      L'unité de dimension de l'échantillon est
+      "<sch:value-of select="normalize-space($units)"/>".
+    </sch:diagnostic>
+  </sch:diagnostics>
+    
+  <sch:pattern id="rule.mrc.sampledimension">
+    <sch:title xml:lang="en">Sample dimension MUST specify units when a max, a min or a mean value is defined.</sch:title>
+    <sch:title xml:lang="fr">La dimension de l'échantillon DOIT spécifier des unités lorsqu'une valeur maximale, 
+      minimale ou moyenne est définie.</sch:title>
+    
+    <sch:rule context="//mrc:MD_SampleDimension[
+      normalize-space(mrc:maxValue/*) != '' or 
+      normalize-space(mrc:minValue/*) != '' or 
+      normalize-space(mrc:meanValue/*) != ''
+      ]">
+      
+      <sch:let name="units" 
+        value="mrc:units[normalize-space(*) != '']"/>
+      
+      <sch:let name="hasUnits" 
+        value="count($units) > 0"/>
+      
+      <sch:assert test="$hasUnits"
+        diagnostics="rule.mrc.sampledimension-failure-en 
+        rule.mrc.sampledimension-failure-fr"/>
+
+      <sch:report test="$hasUnits"
+        diagnostics="rule.mrc.sampledimension-max-success-en 
+        rule.mrc.sampledimension-max-success-fr"/>
+
+    </sch:rule>
+  </sch:pattern>
+  
+  
+  
+  <!-- 
+    Rule: MD_Band
+    Ref: {if count(boundMax + boundMin) > 0 then boundUnits is mandatory}
+    -->
+  
+  <sch:diagnostics>
+    <sch:diagnostic id="rule.mrc.bandunit-failure-en"
+      xml:lang="en">The band defined a bound without unit.</sch:diagnostic>
+    <sch:diagnostic id="rule.mrc.bandunit-failure-fr"
+      xml:lang="fr">La bande définit une borne minimum et/ou maximum
+      sans préciser d'unité.</sch:diagnostic>
+    
+    <sch:diagnostic id="rule.mrc.bandunit-success-en"
+      xml:lang="en">
+      The band bound [<sch:value-of select="$min"/>-<sch:value-of select="$max"/>] unit is 
+      "<sch:value-of select="$units"/>".
+    </sch:diagnostic>
+    <sch:diagnostic id="rule.mrc.bandunit-success-fr"
+      xml:lang="fr">
+      L'unité de la borne [<sch:value-of select="$min"/>-<sch:value-of select="$max"/>] est 
+      "<sch:value-of select="$units"/>".
+    </sch:diagnostic>
+  </sch:diagnostics>
+  
+  <sch:pattern id="rule.mrc.bandunit">
+    <sch:title xml:lang="en">Band MUST specified bounds units 
+      when a bound max or bound min is defined</sch:title>
+    <sch:title xml:lang="fr">Une bande DOIT préciser l'unité 
+      lorsqu'une borne maximum ou minimum est définie</sch:title>
+    
+    <sch:rule context="//mrc:MD_Band[
+      normalize-space(mrc:boundMax/*) != '' or 
+      normalize-space(mrc:boundMin/*) != ''
+      ]">
+      
+      <sch:let name="max" 
+        value="normalize-space(mrc:boundMax/*)"/>
+      <sch:let name="min" 
+        value="normalize-space(mrc:boundMin/*)"/>
+      <sch:let name="units" 
+        value="normalize-space(mrc:boundUnits[normalize-space(*) != ''])"/>
+      
+      <sch:let name="hasUnits" 
+        value="$units != ''"/>
+      
+      <sch:assert test="$hasUnits"
+        diagnostics="rule.mrc.bandunit-failure-en 
+        rule.mrc.bandunit-failure-fr"/>
+      
+      <sch:report test="$hasUnits"
+        diagnostics="rule.mrc.bandunit-success-en 
+                     rule.mrc.bandunit-success-fr"/>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>


### PR DESCRIPTION
Schematron is not provided in the v2.0 namespaces of the current release of the ISO 19115-3 schema files.  This pull request contains new schematron files created for the three namespaces having both a v2.0 release and schematron in the corresponding v1.0 release - the namespaces (abbreviations) are cit, mdb and mrc.

Three v1.0 schematron files have been duplicated and modified to create the v2.0 schematron files.  Modifications consist of changing the edition number from 1.0 to 2.0 in the respective URIs in the namespace declarations.  The assumption is that there are no changes or additions required to the rules in the schematron, i.e. there have been no changes to the ISO 19115-1 constraints from v1.0 and v2.0.

Additional modifications have been made to the v2.0 mrc schematron file to fix a rule which incorrectly applies one of the ISO 19115-1 constraints (see [issue #212](https://github.com/ISO-TC211/XML/issues/212)).

Thanks,

Aaron Sedgmen
Geoscience Australia

 