### PR TITLE
ISO19139 / Mapping / Codelist may have multiple values

### DIFF
--- a/schemas.isotc211.org/19115/resources/transforms/ISO19139/toISO19139.xsl
+++ b/schemas.isotc211.org/19115/resources/transforms/ISO19139/toISO19139.xsl
@@ -640,8 +640,8 @@
     <xsl:param name="codeListName"/>
     <xsl:param name="codeListValue"/>
     <!-- The correct codeList Location goes here -->
-    <xsl:variable name="codeListLocation" select="'codeListLocation'"/>
-    <xsl:if test="$codeListValue">
+    <xsl:variable name="codeListLocation" select="'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml'"/>
+    <xsl:for-each select="$codeListValue">
       <xsl:element name="{$elementName}">
         <xsl:element name="{$codeListName}">
           <xsl:attribute name="codeList">
@@ -650,15 +650,12 @@
             <xsl:value-of select="substring-after($codeListName,':')"/>
           </xsl:attribute>
           <xsl:attribute name="codeListValue">
-            <!-- the anyValidURI value is used for testing with paths -->
-            <xsl:value-of select="$codeListValue"/>
-            <!-- commented out for testing -->
-            <!--<xsl:value-of select="$codeListValue"/>-->
+            <xsl:value-of select="current()"/>
           </xsl:attribute>
-          <xsl:value-of select="$codeListValue"/>
+          <xsl:value-of select="current()"/>
         </xsl:element>
       </xsl:element>
-    </xsl:if>
+    </xsl:for-each>
   </xsl:template>
   
   <xsl:template name="writeCharacterStringElement">


### PR DESCRIPTION
Current mapping may produce invalid ISO19139 record


```xml
         <mri:status>
            <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
                                 codeListValue="obsolete"/>
         </mri:status>
         <mri:status>
            <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
                                 codeListValue="superseded"/>
         </mri:status>
```

produce 19139 with `obsolete superseded` instead of 2 gmd:status element

```xml
      <gmd:status>
        <gmd:MD_ProgressCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode"
                                                 codeListValue="obsolete superseded">obsolete superseded</gmd:MD_ProgressCode>
      </gmd:status>
```