### PR TITLE
XSLT / From 19139 conversion / Fix MD_VectorSpatialRepresentation namespace

### DIFF
--- a/schemas.isotc211.org/19115/resources/transforms/ISO19139/mapping/defaults.xsl
+++ b/schemas.isotc211.org/19115/resources/transforms/ISO19139/mapping/defaults.xsl
@@ -187,7 +187,7 @@
           test="ancestor-or-self::gmd:MD_Georectified or ancestor-or-self::gmi:MI_Georectified
           or ancestor-or-self::gmd:MD_Georeferenceable or ancestor-or-self::gmi:MI_Georeferenceable
           or ancestor-or-self::gmd:MD_GridSpatialRepresentation or ancestor-or-self::gmd:MD_ReferenceSystem
-          or name()=gmi:MI_Metadata">
+          or ancestor-or-self::gmd:MD_VectorSpatialRepresentation or name()=gmi:MI_Metadata">
           <xsl:text>msr</xsl:text>
         </xsl:when>
         <xsl:when test="ancestor-or-self::gmd:DQ_Scope">
@@ -196,7 +196,7 @@
         <xsl:when test="ancestor-or-self::gmd:MD_Distribution or ancestor-or-self::gmd:MD_Format">
           <xsl:text>mrd</xsl:text>
         </xsl:when>
-        <xsl:when test="ancestor-or-self::gmd:MD_Resolution or ancestor-or-self::gmd:MD_RepresentativeFraction or ancestor-or-self::gmd:MD_VectorSpatialRepresentation">
+        <xsl:when test="ancestor-or-self::gmd:MD_Resolution or ancestor-or-self::gmd:MD_RepresentativeFraction>
           <xsl:text>mri</xsl:text>
         </xsl:when>
         <xsl:when test="ancestor-or-self::gmd:MD_MaintenanceInformation">


### PR DESCRIPTION
`MD_VectorSpatialRepresentation` is a type from `msr` namespace not from `mri` Cf. https://github.com/ISO-TC211/XML/blob/master/schemas.isotc211.org/19115/-3/msr/2.0/spatialRepresentation.xsd#L353